### PR TITLE
The tax field of invoice should be a number

### DIFF
--- a/tap_harvest/__init__.py
+++ b/tap_harvest/__init__.py
@@ -43,11 +43,12 @@ def get_start(key):
 def get_url(endpoint):
     return BASE_URL.format(CONFIG['account_name']) + endpoint
 
-@backoff.on_exception(backoff.expo,
-                      (requests.exceptions.RequestException),
-                      max_tries=5,
-                      giveup=lambda e: e.response is not None and 400 <= e.response.status_code < 500,
-                      factor=2)
+@backoff.on_exception(
+    backoff.expo,
+    (requests.exceptions.RequestException),
+    max_tries=5,
+    giveup=lambda e: e.response is not None and 400 <= e.response.status_code < 500,
+    factor=2)
 @utils.ratelimit(100, 15)
 def request(url, params=None):
     params = params or {}

--- a/tap_harvest/schemas/invoices.json
+++ b/tap_harvest/schemas/invoices.json
@@ -52,7 +52,7 @@
       "format": "date-time"
     },
     "tax": {
-      "type": ["null", "string"]
+      "type": ["null", "string", "number"]
     },
     "tax_amount": {
       "type": ["null", "number"]


### PR DESCRIPTION
We are leaving the existing "string" type and adding "number" as another type, because we're not sure how it's currently working at all if the type is string and we don't want to break existing users.