### PR TITLE
tap refreshes its own AT w/ a refresh_token and oauth client creds

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ Author: Jordan Ryan (jordan@facetinteractive.com)
 
     ```json
     {
-        "access_token": "YOUR_OAUTH_TOKEN",
+        "client_id": "OAUTH_CLIENT_ID",
+        "client_secret": "OAUTH_CLIENT_SECRET",
+        "refresh_token": "YOUR_OAUTH_REFRESH_TOKEN",
         "start_date": "2017-04-19T13:37:30Z",
         "account_name": "YOUR_ACCOUNT_NAME"
     }

--- a/circle.yml
+++ b/circle.yml
@@ -8,4 +8,4 @@ dependencies:
 
 test:
   post:
-    - pylint tap_harvest --disable missing-docstring,logging-format-interpolation,no-member,broad-except,redefined-variable-type,too-many-branches
+    - pylint tap_harvest --disable missing-docstring,logging-format-interpolation,no-member,broad-except,redefined-variable-type,too-many-branches,too-few-public-methods,global-statement

--- a/circle.yml
+++ b/circle.yml
@@ -8,4 +8,4 @@ dependencies:
 
 test:
   post:
-    - pylint tap_harvest --disable missing-docstring,logging-format-interpolation,no-member,broad-except,redefined-variable-type,too-many-branches,too-few-public-methods,global-statement
+    - pylint tap_harvest --disable missing-docstring,logging-format-interpolation,no-member,broad-except,redefined-variable-type,too-many-branches,too-few-public-methods

--- a/circle.yml
+++ b/circle.yml
@@ -8,4 +8,4 @@ dependencies:
 
 test:
   post:
-    - pylint tap_harvest --disable missing-docstring,logging-format-interpolation,no-member,broad-except,redefined-variable-type,too-many-branches,too-few-public-methods
+    - pylint tap_harvest --disable missing-docstring,logging-format-interpolation,no-member,broad-except,redefined-variable-type,too-many-branches,too-few-public-methods,wrong-import-order

--- a/tap_harvest/__init__.py
+++ b/tap_harvest/__init__.py
@@ -262,7 +262,7 @@ def do_sync():
 def main_impl():
     args = utils.parse_args(REQUIRED_CONFIG_KEYS)
     CONFIG.update(args.config)
-    global AUTH
+    global AUTH # pylint: disable=global-statement
     AUTH = Auth(CONFIG['client_id'], CONFIG['client_secret'], CONFIG['refresh_token'])
     STATE.update(args.state)
     do_sync()

--- a/tap_harvest/__init__.py
+++ b/tap_harvest/__init__.py
@@ -57,20 +57,20 @@ class Auth:
         try:
             resp_json = resp.json()
             self._access_token = resp_json['access_token']
-        except KeyError as e:
+        except KeyError as key_err:
             if resp_json.get('error'):
                 LOGGER.critical(resp_json.get('error'))
             if resp_json.get('error_description'):
                 LOGGER.critical(resp_json.get('error_description'))
-            raise e
+            raise key_err
         LOGGER.info("Got refreshed access token")
 
     def get_access_token(self):
         if (self._access_token is not None and self._expires_at > pendulum.now()):
             return self._access_token
-        else:
-            self._refresh_access_token()
-            return self._access_token
+
+        self._refresh_access_token()
+        return self._access_token
 
 
 def get_abs_path(path):


### PR DESCRIPTION
This change gives the tap the ability to refresh its own access token, which is desirable for two reasons:

- other taps, like [`tap-salesforce`](https://github.com/singer-io/tap-salesforce/blob/master/tap_salesforce/__init__.py#L342-L344), refresh the access token internally, so this change makes tap-harvest more consistent with other Singer taps in its auth behavior
- expired access tokens can be refreshed during a single sync run


Example run with good credentials:

```
$ tap-harvest -c harvest-config.json
  INFO Refreshing access token
  INFO Got refreshed access token
  INFO Starting sync
...
```

with bad credentials:

```
$ tap-harvest -c harvest-config.json
  INFO Refreshing access token
CRITICAL invalid_client
CRITICAL The client identifier provided is invalid, the client failed to authenticate, the client did not include its credentials, provided multiple client credentials, or used unsupported credentials type.
CRITICAL 'access_token'
...
```
  