### PR TITLE
don't log plaintext AT url param when logging request

### DIFF
--- a/tap_harvest/__init__.py
+++ b/tap_harvest/__init__.py
@@ -100,10 +100,11 @@ def get_url(endpoint):
 @utils.ratelimit(100, 15)
 def request(url, params=None):
     params = params or {}
-    params["access_token"] = AUTH.get_access_token()
+    access_token = AUTH.get_access_token()
+    params["access_token"] = access_token
     headers = {"Accept": "application/json"}
     req = requests.Request("GET", url=url, params=params, headers=headers).prepare()
-    LOGGER.info("GET {}".format(req.url))
+    LOGGER.info("GET {}".format(req.url.replace(access_token, '.' * len(access_token))))
     resp = SESSION.send(req)
     resp.raise_for_status()
     return resp.json()


### PR DESCRIPTION
This tap logs the request URL, which includes the access_token as a URL parameter. This change replaces each character of the AT with a `.` to hide it in the logs.

```
$ tap-harvest -c harvest-config.json > /dev/null
  INFO Refreshing access token
  INFO Got refreshed access token
  INFO Starting sync
  INFO GET https://stitchtest2.harvestapp.com/clients?access_token=......................................................................................
  INFO GET https://stitchtest2.harvestapp.com/contacts?access_token=......................................................................................
  INFO GET https://stitchtest2.harvestapp.com/people?access_token=......................................................................................
  INFO GET https://stitchtest2.harvestapp.com/tasks?access_token=......................................................................................
  INFO GET https://stitchtest2.harvestapp.com/projects?access_token=......................................................................................
  INFO GET https://stitchtest2.harvestapp.com/expense_categories?access_token=......................................................................................
  INFO GET https://stitchtest2.harvestapp.com/expenses?access_token=......................................................................................
  INFO GET https://stitchtest2.harvestapp.com/invoice_item_categories?access_token=......................................................................................
  INFO GET https://stitchtest2.harvestapp.com/invoices?updated_since=2017-04-19+13%3A37&access_token=......................................................................................
  INFO Sync complete
```