### PR TITLE
Fix/pass credentials in header

### DIFF
--- a/tap_harvest/__init__.py
+++ b/tap_harvest/__init__.py
@@ -41,7 +41,7 @@ class Auth:
     def _make_refresh_token_request(self):
         return requests.request('POST',
                                 url='https://api.harvestapp.com/oauth2/token',
-                                params={'client_id': self._client_id,
+                                data={'client_id': self._client_id,
                                         'client_secret': self._client_secret,
                                         'refresh_token': self._refresh_token,
                                         'grant_type': 'refresh_token'})

--- a/tap_harvest/__init__.py
+++ b/tap_harvest/__init__.py
@@ -44,7 +44,8 @@ class Auth:
                                 data={'client_id': self._client_id,
                                       'client_secret': self._client_secret,
                                       'refresh_token': self._refresh_token,
-                                      'grant_type': 'refresh_token'})
+                                      'grant_type': 'refresh_token'},
+                                headers={"User-Agent": CONFIG.get("user_agent")})
 
     def _refresh_access_token(self):
         LOGGER.info("Refreshing access token")

--- a/tap_harvest/__init__.py
+++ b/tap_harvest/__init__.py
@@ -99,10 +99,11 @@ def get_url(endpoint):
 def request(url, params=None):
     params = params or {}
     access_token = AUTH.get_access_token()
-    params["access_token"] = access_token
-    headers = {"Accept": "application/json"}
+    headers = {"Accept": "application/json",
+               "Authorization": "Bearer " + access_token,
+               "User-Agent": CONFIG.get("user_agent")}
     req = requests.Request("GET", url=url, params=params, headers=headers).prepare()
-    LOGGER.info("GET {}".format(req.url.replace(access_token, '.' * len(access_token))))
+    LOGGER.info("GET {}".format(req.url))
     resp = SESSION.send(req)
     resp.raise_for_status()
     return resp.json()

--- a/tap_harvest/__init__.py
+++ b/tap_harvest/__init__.py
@@ -42,9 +42,9 @@ class Auth:
         return requests.request('POST',
                                 url='https://api.harvestapp.com/oauth2/token',
                                 data={'client_id': self._client_id,
-                                        'client_secret': self._client_secret,
-                                        'refresh_token': self._refresh_token,
-                                        'grant_type': 'refresh_token'})
+                                      'client_secret': self._client_secret,
+                                      'refresh_token': self._refresh_token,
+                                      'grant_type': 'refresh_token'})
 
     def _refresh_access_token(self):
         LOGGER.info("Refreshing access token")


### PR DESCRIPTION
Making requests with sensitive data in the URL parameters is not secure, since URL frequently gets logged on the way to the destination server (and may not be secured properly), and is never encrypted. OWASP has a stub about this [here](https://www.owasp.org/index.php/Information_exposure_through_query_strings_in_url).

This PR moves credentials from the URL to the body, or headers (depending on the request being made).