### PR TITLE
Allow external_reference_ids to be strings

### DIFF
--- a/tap_harvest/schemas/external_reference.json
+++ b/tap_harvest/schemas/external_reference.json
@@ -2,7 +2,7 @@
   "type": "object",
   "properties": {
     "id": {
-      "type": ["null", "integer"]
+      "type": ["null", "string"]
     },
     "task_id": {
       "type": ["null", "integer"]

--- a/tap_harvest/schemas/time_entry_external_reference.json
+++ b/tap_harvest/schemas/time_entry_external_reference.json
@@ -5,7 +5,7 @@
       "type": ["null", "integer"]
     },
     "external_reference_id": {
-      "type": ["null", "integer"]
+      "type": ["null", "string"]
     }
   }
 }


### PR DESCRIPTION
Certain external services that Harvest uses may use strings as identifiers instead of integers which can cause issues. 