### PR TITLE
Make group id a string

### DIFF
--- a/tap_harvest/schemas/external_reference.json
+++ b/tap_harvest/schemas/external_reference.json
@@ -8,7 +8,7 @@
       "type": ["null", "integer"]
     },
     "group_id": {
-      "type": ["null", "integer"]
+      "type": ["null", "string"]
     },
     "permalink": {
       "type": ["null", "string"]


### PR DESCRIPTION
Some integrations give a hex value for group ID, which must be interpreted as a string. This PR updates this piece of schema to accept string values.