### PR TITLE
Expense.User Foreign Key to Expense.Creator

### DIFF
--- a/tap_harvest/__init__.py
+++ b/tap_harvest/__init__.py
@@ -196,7 +196,7 @@ def sync_endpoint(schema_name, endpoint=None, path=None, date_fields=None, with_
 
                 if object_to_id is not None:
                     for key in object_to_id:
-                        if row.get(key) is not None:
+                        if row[key] is not None:
                             row[key + '_id'] = row[key]['id']
                         else:
                             row[key + '_id'] = None

--- a/tap_harvest/__init__.py
+++ b/tap_harvest/__init__.py
@@ -196,7 +196,7 @@ def sync_endpoint(schema_name, endpoint=None, path=None, date_fields=None, with_
 
                 if object_to_id is not None:
                     for key in object_to_id:
-                        if row[key] is not None:
+                        if row.get(key) is not None:
                             row[key + '_id'] = row[key]['id']
                         else:
                             row[key + '_id'] = None
@@ -335,7 +335,7 @@ def sync_estimates():
     sync_endpoint("estimates",
                   for_each_handler=for_each_estimate,
                   date_fields=["issue_date"],
-                  object_to_id=['client', 'user'])
+                  object_to_id=['client', 'creator'])
 
 
 def sync_roles():


### PR DESCRIPTION
Related to #25

The `expenses` stream was specifying that the foreign key user object was `user` when it actually was `creator`. Also, the code that grabs this was intending it to be nullable, but wasn't safely getting the value, so a `KeyError: User` was thrown, since user is not a field on expense.

This addresses the first concern. I'm deciding not to address the second, due to the possibility of accidentally null-ing out the data if the key specified doesn't exist in the record. This is a case where it'd be better to announce that it doesn't exist, than continue silently with null values.