### PR TITLE
Fix/date time formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 2.0.5
-  * Fixes `expenses` stream to use `expense.creator` instead of `expense.user` [#26](https://github.com/singer-io/tap-harvest/pull/26)
+  * Fixes `estimates` stream to use `estimate.creator` instead of `estimate.user` [#26](https://github.com/singer-io/tap-harvest/pull/26)
 
 ## 2.0.4
   * Fixes schema of `external_reference.group_id` to be a string [#24](https://github.com/singer-io/tap-harvest/pull/24)

--- a/tap_harvest/__init__.py
+++ b/tap_harvest/__init__.py
@@ -157,7 +157,7 @@ def append_times_to_dates(item, date_fields):
     if date_fields:
         for date_field in date_fields:
             if item.get(date_field):
-                item[date_field] += "T00:00:00Z"
+                item[date_field] = utils.strftime(utils.strptime_with_tz(item[date_field]))
 
 
 def get_company():


### PR DESCRIPTION
While processing datetimes, the code was blindly appending a time to fields that it assumed were dates only. This will parse dates using singer utilities and re-format them into strings for emitting as records.

e.g., The datetime `issue_date: "2018-09-20T00:00:00.000000Z"` would become `2018-09-20T00:00:00.000000ZT00:00:00Z`, since `issue_date` is assumed to be only in `Y-m-d` format.