### PR TITLE
TDL-13969:  Discovery Mode should check permissions of the token given

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
       - run:
           name: 'Unit Tests'
           command: |
-            source /usr/local/share/virtualenvs/tap-harvest/bin/activate
+            source ~/.virtualenvs/tap-harvest/bin/activate
             pip install nose
             nosetests tests/unittests/
       - add_ssh_keys

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,12 @@ jobs:
           command: |
             source ~/.virtualenvs/tap-harvest/bin/activate
             pylint tap_harvest --disable missing-docstring,logging-format-interpolation,no-member,broad-except,redefined-variable-type,too-many-branches,too-few-public-methods,wrong-import-order,too-many-locals
+      - run:
+          name: 'Unit Tests'
+          command: |
+            source /usr/local/share/virtualenvs/tap-harvest/bin/activate
+            pip install nose
+            nosetests tests/unittests/
       - add_ssh_keys
       - run:
           name: 'Integration Tests'

--- a/tap_harvest/__init__.py
+++ b/tap_harvest/__init__.py
@@ -459,6 +459,8 @@ def do_sync():
     LOGGER.info("Sync complete")
 
 def do_discover():
+    # Get company for token permission validation
+    get_company()
     print('{"streams":[]}')
 
 def main_impl():

--- a/tests/test_harvest_pagination.py
+++ b/tests/test_harvest_pagination.py
@@ -141,7 +141,7 @@ class PaginationTest(BaseTapTest):
                 # NOTE: time_entries has fields which are set to null in a create and so do not get picked up
                 # automatically when checking the keys, so we set partial expectations manually.
                 add_expected = {'invoice_id'}
-                remove_expected = {'invoice', 'timer_started_at', 'rounded_hours'} # BUG (for timer_started_at see clients bug above)
+                remove_expected = {'invoice', 'timer_started_at', 'rounded_hours', 'hours_without_timer'} # BUG (for timer_started_at see clients bug above)
                 expectations = add_expected.union(get_fields(time_entry) - remove_expected)
                 cls._master["time_entries"]["expected_fields"].update(expectations)
                 cls._master["time_entries"]["delete_me"].append({"id": time_entry['id']})

--- a/tests/unittests/test_token_in_discover_mode.py
+++ b/tests/unittests/test_token_in_discover_mode.py
@@ -10,7 +10,7 @@ def get_mock_http_response(status_code, content={}):
     contents = json.dumps(content)
     response = requests.Response()
     response.status_code = status_code
-    response.headers = {"X-RateLimit-Reset": 2, "X-Rate-Limit-Problem": "minute"}
+    response.headers = {}
     response._content = contents.encode()
     return response
 

--- a/tests/unittests/test_token_in_discover_mode.py
+++ b/tests/unittests/test_token_in_discover_mode.py
@@ -1,0 +1,77 @@
+from unittest import mock
+
+from requests.models import HTTPError
+import tap_harvest
+import unittest
+import requests
+import json
+
+def get_mock_http_response(status_code, content={}):
+    contents = json.dumps(content)
+    response = requests.Response()
+    response.status_code = status_code
+    response.headers = {"X-RateLimit-Reset": 2, "X-Rate-Limit-Problem": "minute"}
+    response._content = contents.encode()
+    return response
+
+@mock.patch("tap_harvest.AUTH")
+@mock.patch("requests.Session.send")
+@mock.patch("requests.Request")
+@mock.patch("builtins.print")
+class TestAccessToken(unittest.TestCase):
+
+    def test_200_response(self, mocked_print, mocked_request, mocked_send_request, mocked_auth):
+        mocked_send_request.return_value = get_mock_http_response(200, {})
+        tap_harvest.do_discover()
+        self.assertEqual(mocked_print.call_count, 1)
+        mocked_print.assert_called_with('{"streams":[]}')
+
+    def test_401_error(self, mocked_print, mocked_request, mocked_send_request, mocked_auth):
+        mocked_send_request.return_value = get_mock_http_response(401, {})
+        try:
+            tap_harvest.do_discover()
+        except HTTPError as e:
+            self.assertEqual(e.response.status_code, 401)
+            self.assertEqual(mocked_print.call_count, 0)
+
+
+    def test_403_error(self, mocked_print, mocked_request, mocked_send_request, mocked_auth):
+        mocked_send_request.return_value = get_mock_http_response(403, {})
+        try:
+            tap_harvest.do_discover()
+        except HTTPError as e:
+            self.assertEqual(e.response.status_code, 403)
+            self.assertEqual(mocked_print.call_count, 0)
+
+    def test_404_error(self, mocked_print, mocked_request, mocked_send_request, mocked_auth):
+        mocked_send_request.return_value = get_mock_http_response(404, {})
+        try:
+            tap_harvest.do_discover()
+        except HTTPError as e:
+            self.assertEqual(e.response.status_code, 404)
+            self.assertEqual(mocked_print.call_count, 0)
+
+    def test_422_error(self, mocked_print, mocked_request, mocked_send_request, mocked_auth):
+        mocked_send_request.return_value = get_mock_http_response(422, {})
+        try:
+            tap_harvest.do_discover()
+        except HTTPError as e:
+            self.assertEqual(e.response.status_code, 422)
+            self.assertEqual(mocked_print.call_count, 0)
+
+    def test_429_error(self, mocked_print, mocked_request, mocked_send_request, mocked_auth):
+        mocked_send_request.return_value = get_mock_http_response(429, {})
+        try:
+            tap_harvest.do_discover()
+        except HTTPError as e:
+            self.assertEqual(e.response.status_code, 429)
+            self.assertEqual(mocked_print.call_count, 0)
+
+    @mock.patch("time.sleep")
+    def test_500_error(self, mocked_sleep, mocked_print, mocked_request, mocked_send_request, mocked_auth):
+        mocked_send_request.return_value = get_mock_http_response(500, {})
+        try:
+            tap_harvest.do_discover()
+        except HTTPError as e:
+            self.assertEqual(e.response.status_code, 500)
+            self.assertEqual(mocked_print.call_count, 0)


### PR DESCRIPTION
# Description of change
TDL-13969: Discovery Mode should check permissions of the token given
- Added API call for getting company endpoint during discovery mode to validate the token.

# Manual QA steps
 - Verified that tap is raising an exception if get company call failed with error code.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
