### PR TITLE
TDL-16326: Implement request timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,8 +21,13 @@ jobs:
           name: 'Unit Tests'
           command: |
             source ~/.virtualenvs/tap-harvest/bin/activate
-            pip install nose
-            nosetests tests/unittests/
+            pip install nose coverage
+            nosetests --with-coverage --cover-erase --cover-package=tap_harvest --cover-html-dir=htmlcov tests/unittests
+            coverage html
+      - store_test_results:
+          path: test_output/report.xml
+      - store_artifacts:
+          path: htmlcov
       - add_ssh_keys
       - run:
           name: 'Integration Tests'

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ API V2 Author: Steven Hernandez (steven.hernandez@fostermade.co)
         "client_secret": "OAUTH_CLIENT_SECRET",
         "refresh_token": "YOUR_OAUTH_REFRESH_TOKEN",
         "start_date": "2017-04-19T13:37:30Z",
-        "user_agent": "MyApp (your.email@example.com)"
+        "user_agent": "MyApp (your.email@example.com)",
+        "request_timeout": 300
     }
     ```
 

--- a/tap_harvest/__init__.py
+++ b/tap_harvest/__init__.py
@@ -131,7 +131,8 @@ def get_request_timeout():
     if config_request_timeout and float(config_request_timeout):
         request_timeout = float(config_request_timeout)
     else:
-        request_timeout = REQUEST_TIMEOUT # If value is 0,"0","" or not passed then it set default to 300 seconds.
+        # If value is 0,"0","" or not passed then it set default to 300 seconds.
+        request_timeout = REQUEST_TIMEOUT
     return request_timeout
 
 # backoff for Timeout error is already included in "requests.exceptions.RequestException"

--- a/tap_harvest/__init__.py
+++ b/tap_harvest/__init__.py
@@ -27,7 +27,8 @@ STATE = {}
 # which leads to data loss as it is updated after every sync
 TAP_STATE = {}
 AUTH = {}
-
+# timeout request after 300 seconds
+REQUEST_TIMEOUT = 300
 
 class Auth:
     def __init__(self, client_id, client_secret, refresh_token):
@@ -37,6 +38,8 @@ class Auth:
         self._account_id = None
         self._refresh_access_token()
 
+    # backoff for Timeout error is already included in "requests.exceptions.RequestException"
+    # as it is a parent class of "Timeout" error
     @backoff.on_exception(
         backoff.expo,
         requests.exceptions.RequestException,
@@ -52,7 +55,8 @@ class Auth:
                                     'refresh_token': self._refresh_token,
                                     'grant_type': 'refresh_token',
                                 },
-                                headers={"User-Agent": CONFIG.get("user_agent")})
+                                headers={"User-Agent": CONFIG.get("user_agent")},
+                                timeout=get_request_timeout())
 
     def _refresh_access_token(self):
         LOGGER.info("Refreshing access token")
@@ -85,7 +89,8 @@ class Auth:
         response = requests.request('GET',
                                     url=BASE_ID_URL + 'accounts',
                                     headers={'Authorization': 'Bearer ' + self._access_token,
-                                             'User-Agent': CONFIG.get("user_agent")})
+                                             'User-Agent': CONFIG.get("user_agent")},
+                                    timeout=get_request_timeout())
 
         if response.json().get('accounts'):
             self._account_id = str(response.json()['accounts'][0]['id'])
@@ -118,7 +123,19 @@ def get_start(key):
 def get_url(endpoint):
     return BASE_API_URL + endpoint
 
+def get_request_timeout():
+    # Get `request_timeout` value from config.
+    config_request_timeout = CONFIG.get('request_timeout')
 
+    # if config request_timeout is other than 0,"0" or "" then use request_timeout
+    if config_request_timeout and float(config_request_timeout):
+        request_timeout = float(config_request_timeout)
+    else:
+        request_timeout = REQUEST_TIMEOUT # If value is 0,"0","" or not passed then it set default to 300 seconds.
+    return request_timeout
+
+# backoff for Timeout error is already included in "requests.exceptions.RequestException"
+# as it is a parent class of "Timeout" error
 @backoff.on_exception(
     backoff.expo,
     requests.exceptions.RequestException,
@@ -135,7 +152,7 @@ def request(url, params=None):
                "User-Agent": CONFIG.get("user_agent")}
     req = requests.Request("GET", url=url, params=params, headers=headers).prepare()
     LOGGER.info("GET {}".format(req.url))
-    resp = SESSION.send(req)
+    resp = SESSION.send(req, timeout=get_request_timeout())
     resp.raise_for_status()
     return resp.json()
 

--- a/tests/unittests/test_request_timeout.py
+++ b/tests/unittests/test_request_timeout.py
@@ -1,0 +1,166 @@
+import tap_harvest
+import unittest
+import requests
+from unittest import mock
+
+# Mock response object
+def get_mock_http_response(*args, **kwargs):
+    contents = '{"access_token": "test", "expires_in":100, "accounts":[{"id": 12}]}'
+    response = requests.Response()
+    response.status_code = 200
+    response._content = contents.encode()
+    return response
+
+@mock.patch('requests.request', side_effect = get_mock_http_response)
+@mock.patch('requests.Session.send')
+@mock.patch("requests.Request.prepare")
+class TestRequestTimeoutValue(unittest.TestCase):
+
+    def test_no_request_timeout_in_config(self, mocked_prepare, mocked_send, mocked_request):
+        """
+            Verify that if request_timeout is not provided in config then default value is used
+        """
+        tap_harvest.CONFIG = {} # No request_timeout in config
+        tap_harvest.AUTH = tap_harvest.Auth("test", "test", "test")
+
+        # Call request method which call requests.request and Session.send with timeout
+        tap_harvest.request("http://test")
+
+        # Verify requests.request and Session.send is called with expected timeout
+        args, kwargs = mocked_send.call_args
+        self.assertEqual(kwargs.get('timeout'), 300) # Verify timeout argument
+        args, kwargs = mocked_request.call_args
+        self.assertEqual(kwargs.get('timeout'), 300) # Verify timeout argument
+
+    def test_integer_request_timeout_in_config(self, mocked_prepare, mocked_send, mocked_request):
+        """
+            Verify that if request_timeout is provided in config(integer value) then it should be use
+        """
+        tap_harvest.CONFIG = {"request_timeout": 100} # integer timeout in config
+        tap_harvest.AUTH = tap_harvest.Auth("test", "test", "test")
+
+        # Call request method which call requests.request and Session.send with timeout
+        tap_harvest.request("http://test")
+
+        # Verify requests.request and Session.send is called with expected timeout
+        args, kwargs = mocked_send.call_args
+        self.assertEqual(kwargs.get('timeout'), 100.0) # Verify timeout argument
+        args, kwargs = mocked_request.call_args
+        self.assertEqual(kwargs.get('timeout'), 100.0) # Verify timeout argument
+
+    def test_float_request_timeout_in_config(self, mocked_prepare, mocked_send, mocked_request):
+        """
+            Verify that if request_timeout is provided in config(float value) then it should be use
+        """
+        tap_harvest.CONFIG = {"request_timeout": 100.5} # float timeout in config
+        tap_harvest.AUTH = tap_harvest.Auth("test", "test", "test")
+
+        # Call request method which call requests.request and Session.send with timeout
+        tap_harvest.request("http://test")
+
+        # Verify requests.request and Session.send is called with expected timeout
+        args, kwargs = mocked_send.call_args
+        self.assertEqual(kwargs.get('timeout'), 100.5) # Verify timeout argument
+        args, kwargs = mocked_request.call_args
+        self.assertEqual(kwargs.get('timeout'), 100.5) # Verify timeout argument
+
+    def test_string_request_timeout_in_config(self, mocked_prepare, mocked_send, mocked_request):
+        """
+            Verify that if request_timeout is provided in config(string value) then it should be use
+        """
+        tap_harvest.CONFIG = {"request_timeout": "100"} # string format timeout in config
+        tap_harvest.AUTH = tap_harvest.Auth("test", "test", "test")
+
+        # Call request method which call requests.request and Session.send with timeout
+        tap_harvest.request("http://test")
+
+        # Verify requests.request and Session.send is called with expected timeout
+        args, kwargs = mocked_send.call_args
+        self.assertEqual(kwargs.get('timeout'), 100) # Verify timeout argument
+        args, kwargs = mocked_request.call_args
+        self.assertEqual(kwargs.get('timeout'), 100) # Verify timeout argument
+
+    def test_empty_string_request_timeout_in_config(self, mocked_prepare, mocked_send, mocked_request):
+        """
+            Verify that if request_timeout is provided in config with empty string then default value is used
+        """
+        tap_harvest.CONFIG = {"request_timeout": ""} # empty string in config
+        tap_harvest.AUTH = tap_harvest.Auth("test", "test", "test")
+
+        # Call request method which call requests.request and Session.send with timeout
+        tap_harvest.request("http://test")
+
+        # Verify requests.request and Session.send is called with expected timeout
+        args, kwargs = mocked_send.call_args
+        self.assertEqual(kwargs.get('timeout'), 300) # Verify timeout argument
+        args, kwargs = mocked_request.call_args
+        self.assertEqual(kwargs.get('timeout'), 300) # Verify timeout argument
+
+    def test_zero_request_timeout_in_config(self, mocked_prepare, mocked_send, mocked_request):
+        """
+            Verify that if request_timeout is provided in config with zero value then default value is used
+        """
+        tap_harvest.CONFIG = {"request_timeout": 0.0} # zero value in config
+        tap_harvest.AUTH = tap_harvest.Auth("test", "test", "test")
+
+        # Call request method which call requests.request and Session.send with timeout
+        tap_harvest.request("http://test")
+
+        # Verify requests.request and Session.send is called with expected timeout
+        args, kwargs = mocked_send.call_args
+        self.assertEqual(kwargs.get('timeout'), 300) # Verify timeout argument
+        args, kwargs = mocked_request.call_args
+        self.assertEqual(kwargs.get('timeout'), 300) # Verify timeout argument
+
+    def test_zero_string_request_timeout_in_config(self, mocked_prepare, mocked_send, mocked_request):
+        """
+            Verify that if request_timeout is provided in config with zero in string format then default value is used
+        """
+        tap_harvest.CONFIG = {"request_timeout": '0.0'} # zero value in config
+        tap_harvest.AUTH = tap_harvest.Auth("test", "test", "test")
+
+        # Call request method which call requests.request and Session.send with timeout
+        tap_harvest.request("http://test")
+
+        # Verify requests.request and Session.send is called with expected timeout
+        args, kwargs = mocked_send.call_args
+        self.assertEqual(kwargs.get('timeout'), 300) # Verify timeout argument
+        args, kwargs = mocked_request.call_args
+        self.assertEqual(kwargs.get('timeout'), 300) # Verify timeout argument
+
+
+@mock.patch("time.sleep")
+class TestRequestTimeoutBackoff(unittest.TestCase):
+
+    @mock.patch('requests.request', side_effect = get_mock_http_response)
+    @mock.patch('requests.Session.send', side_effect = requests.exceptions.Timeout)
+    @mock.patch("requests.Request.prepare",)
+    def test_request_timeout_backoff(self, mocked_prepare, mocked_send, mocked_request, mocked_sleep):
+        """
+            Verify request function is backoff for 5 times on Timeout exceeption
+        """
+        tap_harvest.AUTH = tap_harvest.Auth("test", "test", "test")
+
+        try:
+            tap_harvest.request("http://test")
+        except requests.exceptions.Timeout:
+            pass
+
+        # Verify that Session.send is called 5 times
+        self.assertEqual(mocked_send.call_count, 5)
+
+    @mock.patch('requests.request', side_effect = requests.exceptions.Timeout)
+    @mock.patch("tap_harvest.Auth._refresh_access_token")
+    def test_timeout_backoff_for_make_refresh_token_request(self, mocked_token, mocked_request, mocked_sleep):
+        """
+            Verify _make_refresh_token_request function is backoff for 5 times on Timeout exceeption
+        """
+        auth = tap_harvest.Auth("test", "test", "test")
+
+        try:
+            auth._make_refresh_token_request()
+        except Exception:
+            pass
+
+        # Verify that requests.request is called 5 times
+        self.assertEqual(mocked_request.call_count, 5)


### PR DESCRIPTION
# Description of change
[TDL-16326](https://jira.talendforge.org/browse/TDL-16326): Implement request timeout
- Added request timeout for API requests with default timeout 300 seconds

# Manual QA steps
 - Set small timeout and verified that sync calls are backing off for timeout error.
- Provided timeout in integer, float, and string format and verified that it's used in the request.

 
# Risks
 - 
 
# Rollback steps
 - revert this branch
