### PR TITLE
Updated libraries to latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.1.0
+  * Upgrade `singer-python` from `6.1.1` to `6.8.0`
+  * Add unit tests for `sync`, `discover`, `schema`, `client`, and `streams` modules [#71](https://github.com/singer-io/tap-harvest/pull/71)
 
 ## 3.0.0
   * Add discovery support [#64](https://github.com/singer-io/tap-harvest/pull/64)

--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,14 @@ from setuptools import setup, find_packages
 
 setup(
     name="tap-harvest",
-    version="3.0.0",
+    version="3.1.0",
     description="Singer.io tap for extracting data from the Harvest api",
     author="Facet Interactive",
     url="http://singer.io",
     classifiers=["Programming Language :: Python :: 3 :: Only"],
     py_modules=["tap_harvest"],
     install_requires=[
-        "singer-python==6.1.1",
+        "singer-python==6.8.0",
         "requests==2.32.5",
         "backoff==2.2.1",
     ],

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -1,0 +1,88 @@
+import unittest
+from unittest.mock import patch
+from singer.catalog import Catalog
+
+from tap_harvest.discover import discover
+
+
+class TestDiscover(unittest.TestCase):
+    """Tests for tap_harvest.discover.discover()."""
+
+    @patch("tap_harvest.discover.get_schemas")
+    def test_discover_returns_catalog(self, mock_get_schemas):
+        """discover() returns a Catalog object."""
+        mock_schema = {
+            "type": "object",
+            "properties": {"id": {"type": "integer"}, "updated_at": {"type": "string"}},
+        }
+        mock_mdata = [
+            {
+                "breadcrumb": [],
+                "metadata": {
+                    "table-key-properties": ["id"],
+                    "forced-replication-method": "INCREMENTAL",
+                    "valid-replication-keys": ["updated_at"],
+                },
+            }
+        ]
+        mock_get_schemas.return_value = (
+            {"clients": mock_schema},
+            {"clients": mock_mdata},
+        )
+
+        catalog = discover()
+
+        self.assertIsInstance(catalog, Catalog)
+        self.assertEqual(len(catalog.streams), 1)
+        self.assertEqual(catalog.streams[0].stream, "clients")
+        self.assertEqual(catalog.streams[0].tap_stream_id, "clients")
+
+    @patch("tap_harvest.discover.get_schemas")
+    def test_discover_sets_key_properties(self, mock_get_schemas):
+        """discover() sets key_properties from metadata table-key-properties."""
+        mock_schema = {
+            "type": "object",
+            "properties": {"id": {"type": "integer"}},
+        }
+        mock_mdata = [
+            {
+                "breadcrumb": [],
+                "metadata": {
+                    "table-key-properties": ["id"],
+                    "forced-replication-method": "FULL_TABLE",
+                    "valid-replication-keys": [],
+                },
+            }
+        ]
+        mock_get_schemas.return_value = (
+            {"roles": mock_schema},
+            {"roles": mock_mdata},
+        )
+
+        catalog = discover()
+        self.assertEqual(catalog.streams[0].key_properties, ["id"])
+
+    @patch("tap_harvest.discover.get_schemas")
+    def test_discover_multiple_streams(self, mock_get_schemas):
+        """discover() handles multiple streams without error."""
+        make_schema = lambda: {
+            "type": "object",
+            "properties": {"id": {"type": "integer"}, "updated_at": {"type": "string"}},
+        }
+        make_mdata = lambda: [
+            {
+                "breadcrumb": [],
+                "metadata": {
+                    "table-key-properties": ["id"],
+                    "forced-replication-method": "INCREMENTAL",
+                    "valid-replication-keys": ["updated_at"],
+                },
+            }
+        ]
+        schemas = {name: make_schema() for name in ["clients", "projects", "tasks"]}
+        field_metadata = {name: make_mdata() for name in ["clients", "projects", "tasks"]}
+        mock_get_schemas.return_value = (schemas, field_metadata)
+
+        catalog = discover()
+        stream_ids = {s.tap_stream_id for s in catalog.streams}
+        self.assertEqual(stream_ids, {"clients", "projects", "tasks"})

--- a/tests/unittests/test_init.py
+++ b/tests/unittests/test_init.py
@@ -1,0 +1,55 @@
+import io
+import json
+import unittest
+from unittest.mock import patch, MagicMock
+import tap_harvest
+
+
+class TestDoDiscover(unittest.TestCase):
+    """Tests for tap_harvest.do_discover()."""
+
+    @patch("tap_harvest.discover")
+    def test_do_discover_dumps_catalog(self, mock_discover):
+        """do_discover() serialises catalog to stdout."""
+        mock_catalog = MagicMock()
+        mock_catalog.to_dict.return_value = {"streams": []}
+        mock_discover.return_value = mock_catalog
+
+        captured = io.StringIO()
+        with patch("sys.stdout", captured):
+            tap_harvest.do_discover()
+
+        mock_discover.assert_called_once()
+        mock_catalog.to_dict.assert_called_once()
+        output = json.loads(captured.getvalue())
+        self.assertEqual(output, {"streams": []})
+
+    @patch("tap_harvest.discover")
+    def test_do_discover_logs_start_and_finish(self, mock_discover):
+        """do_discover() logs start and finish messages."""
+        mock_catalog = MagicMock()
+        mock_catalog.to_dict.return_value = {}
+        mock_discover.return_value = mock_catalog
+
+        with patch("tap_harvest.LOGGER") as mock_logger:
+            with patch("sys.stdout", io.StringIO()):
+                tap_harvest.do_discover()
+
+        self.assertTrue(mock_logger.info.called)
+        calls = [str(c) for c in mock_logger.info.call_args_list]
+        self.assertTrue(any("discover" in c.lower() for c in calls))
+
+
+class TestRequiredConfigKeys(unittest.TestCase):
+    """Tests for REQUIRED_CONFIG_KEYS."""
+
+    def test_required_config_keys_present(self):
+        import tap_harvest
+        expected = {
+            "refresh_token",
+            "client_id",
+            "client_secret",
+            "start_date",
+            "user_agent",
+        }
+        self.assertEqual(set(tap_harvest.REQUIRED_CONFIG_KEYS), expected)

--- a/tests/unittests/test_schema.py
+++ b/tests/unittests/test_schema.py
@@ -1,0 +1,114 @@
+import os
+import json
+import unittest
+from unittest.mock import patch, mock_open, MagicMock
+
+from tap_harvest.schema import get_abs_path, load_schema_references, get_schemas, write_schema
+from tap_harvest.streams import STREAMS
+
+
+class TestGetAbsPath(unittest.TestCase):
+    """Tests for tap_harvest.schema.get_abs_path()."""
+
+    def test_returns_absolute_path(self):
+
+        result = get_abs_path("schemas/clients.json")
+        self.assertTrue(os.path.isabs(result))
+        self.assertTrue(result.endswith("schemas/clients.json") or
+                        result.endswith(os.path.join("schemas", "clients.json")))
+
+
+class TestLoadSchemaReferences(unittest.TestCase):
+    """Tests for tap_harvest.schema.load_schema_references()."""
+
+    def test_returns_empty_dict_when_shared_dir_missing(self):
+        with patch("tap_harvest.schema.os.path.exists", return_value=False):
+            result = load_schema_references()
+        self.assertEqual(result, {})
+
+    def test_loads_shared_files(self):
+        fake_content = {"type": "object"}
+        fake_files = ["address.json"]
+
+        with patch("tap_harvest.schema.os.path.exists", return_value=True), \
+             patch("tap_harvest.schema.os.listdir", return_value=fake_files), \
+             patch("tap_harvest.schema.os.path.isfile", return_value=True), \
+             patch("builtins.open", mock_open(read_data=json.dumps(fake_content))):
+            result = load_schema_references()
+
+        self.assertIn("shared/address.json", result)
+        self.assertEqual(result["shared/address.json"], fake_content)
+
+
+class TestGetSchemas(unittest.TestCase):
+    """Tests for tap_harvest.schema.get_schemas()."""
+
+    def test_get_schemas_returns_dicts(self):
+        schemas, field_metadata = get_schemas()
+        self.assertIsInstance(schemas, dict)
+        self.assertIsInstance(field_metadata, dict)
+        self.assertGreater(len(schemas), 0)
+        self.assertEqual(schemas.keys(), field_metadata.keys())
+
+    def test_get_schemas_contains_all_streams(self):
+        schemas, field_metadata = get_schemas()
+        for stream_name in STREAMS:
+            self.assertIn(stream_name, schemas, f"Missing schema for '{stream_name}'")
+            self.assertIn(stream_name, field_metadata, f"Missing metadata for '{stream_name}'")
+
+    def test_each_schema_has_properties(self):
+        schemas, _ = get_schemas()
+        for stream_name, schema in schemas.items():
+            self.assertIn("properties", schema, f"Schema for '{stream_name}' missing 'properties'")
+
+
+class TestWriteSchema(unittest.TestCase):
+    """Tests for tap_harvest.schema.write_schema()."""
+
+    def _make_stream(self, children=None, selected=True):
+        stream = MagicMock()
+        stream.is_selected.return_value = selected
+        stream.children = children or []
+        return stream
+
+    @patch("tap_harvest.schema.STREAMS")
+    def test_write_schema_selected_stream(self, mock_streams):
+        """write_schema() calls stream.write_schema() when stream is selected."""
+
+        stream = self._make_stream(selected=True)
+        mock_client = MagicMock()
+        catalog = MagicMock()
+
+        write_schema(stream, mock_client, [], catalog)
+
+        stream.write_schema.assert_called_once()
+
+    @patch("tap_harvest.schema.STREAMS")
+    def test_write_schema_not_selected(self, mock_streams):
+        """write_schema() does NOT call stream.write_schema() when stream is not selected."""
+
+        stream = self._make_stream(selected=False)
+        write_schema(stream, MagicMock(), [], MagicMock())
+
+        stream.write_schema.assert_not_called()
+
+    @patch("tap_harvest.schema.STREAMS")
+    def test_write_schema_recurses_into_children(self, mock_streams):
+        """write_schema() recurses into children and populates child_to_sync."""
+
+        child_instance = MagicMock()
+        child_instance.is_selected.return_value = True
+        child_instance.children = []
+
+        child_cls = MagicMock(return_value=child_instance)
+        mock_streams.__getitem__.return_value = child_cls
+        mock_streams.__contains__ = lambda self_, item: True
+
+        parent_stream = self._make_stream(selected=True, children=["child_stream"])
+        catalog = MagicMock()
+        catalog.get_stream.return_value = MagicMock()
+
+        write_schema(parent_stream, MagicMock(), ["child_stream"], catalog)
+
+        # child_to_sync should have one entry
+        parent_stream.child_to_sync.append.assert_called_once_with(child_instance)

--- a/tests/unittests/test_streams.py
+++ b/tests/unittests/test_streams.py
@@ -1,0 +1,218 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from tap_harvest.streams.abstracts import (
+    BaseStream,
+    IncrementalStream,
+    ParentBaseStream,
+    ChildBaseStream,
+)
+
+
+# ---------------------------------------------------------------------------
+# Concrete helpers
+# ---------------------------------------------------------------------------
+
+def _make_catalog(schema_dict=None, metadata=None):
+    catalog = MagicMock()
+    catalog.schema.to_dict.return_value = schema_dict or {"properties": {}}
+    catalog.metadata = metadata or []
+    return catalog
+
+
+class ConcreteIncremental(IncrementalStream):
+    tap_stream_id = "test_stream"
+    key_properties = ["id"]
+    replication_method = "INCREMENTAL"
+    replication_keys = ["updated_at"]
+    data_key = "items"
+    path = "items"
+
+
+class ConcreteChild(ChildBaseStream):
+    tap_stream_id = "child_stream"
+    key_properties = ["id"]
+    replication_method = "INCREMENTAL"
+    replication_keys = ["updated_at"]
+    data_key = "children"
+    path = "parents/{0}/children"
+
+
+# ---------------------------------------------------------------------------
+# BaseStream helpers
+# ---------------------------------------------------------------------------
+
+class TestAddObjectToId(unittest.TestCase):
+
+    @patch("tap_harvest.streams.abstracts.metadata.to_map", return_value={})
+    def setUp(self, _):
+        self.stream = ConcreteIncremental(catalog=_make_catalog())
+        self.stream.object_to_id = ["user", "project"]
+
+    def test_adds_id_from_nested_object(self):
+        record = {"user": {"id": 42}, "project": {"id": 7}}
+        result = self.stream.add_object_to_id(record)
+        self.assertEqual(result["user_id"], 42)
+        self.assertEqual(result["project_id"], 7)
+
+    def test_sets_id_to_none_when_object_is_none(self):
+        record = {"user": None, "project": {"id": 7}}
+        result = self.stream.add_object_to_id(record)
+        self.assertIsNone(result["user_id"])
+        self.assertEqual(result["project_id"], 7)
+
+
+class TestAppendTimesToDates(unittest.TestCase):
+
+    @patch("tap_harvest.streams.abstracts.metadata.to_map", return_value={})
+    def setUp(self, _):
+        self.stream = ConcreteIncremental(catalog=_make_catalog())
+        self.stream.date_fields = ["start_date"]
+
+    def test_converts_date_string(self):
+        record = {"start_date": "2024-01-15"}
+        self.stream.append_times_to_dates(record)
+        # Should still be a string and non-empty
+        self.assertIsInstance(record["start_date"], str)
+        self.assertTrue(len(record["start_date"]) > 0)
+
+    def test_skips_missing_date_field(self):
+        record = {}
+        # Should not raise even if date_field is absent
+        self.stream.append_times_to_dates(record)
+
+
+class TestUpdateParams(unittest.TestCase):
+
+    @patch("tap_harvest.streams.abstracts.metadata.to_map", return_value={})
+    def setUp(self, _):
+        self.stream = ConcreteIncremental(catalog=_make_catalog())
+
+    def test_updates_params_when_support_filter(self):
+        self.stream.support_filter = True
+        self.stream.update_params(updated_since="2024-01-01", page=1)
+        self.assertEqual(self.stream.params["updated_since"], "2024-01-01")
+        self.assertEqual(self.stream.params["page"], 1)
+
+    def test_does_not_update_params_when_filter_disabled(self):
+        self.stream.support_filter = False
+        self.stream.update_params(updated_since="2024-01-01")
+        self.assertNotIn("updated_since", self.stream.params)
+
+
+class TestGetRecords(unittest.TestCase):
+
+    @patch("tap_harvest.streams.abstracts.metadata.to_map", return_value={})
+    def setUp(self, _):
+        self.mock_client = MagicMock()
+        self.stream = ConcreteIncremental(
+            client=self.mock_client, catalog=_make_catalog()
+        )
+
+    def test_paginates_until_no_next_page(self):
+        self.mock_client.get.side_effect = [
+            {"items": [{"id": 1}, {"id": 2}], "next_page": 2},
+            {"items": [{"id": 3}], "next_page": None},
+        ]
+        records = list(self.stream.get_records())
+        self.assertEqual(len(records), 3)
+        self.assertEqual(self.mock_client.get.call_count, 2)
+
+    def test_returns_empty_when_no_records(self):
+        self.mock_client.get.return_value = {"items": [], "next_page": None}
+        records = list(self.stream.get_records())
+        self.assertEqual(records, [])
+
+
+# ---------------------------------------------------------------------------
+# IncrementalStream.get_bookmark / write_bookmark
+# ---------------------------------------------------------------------------
+
+class TestIncrementalStreamBookmarks(unittest.TestCase):
+
+    @patch("tap_harvest.streams.abstracts.metadata.to_map", return_value={})
+    def setUp(self, _):
+        self.mock_client = MagicMock()
+        self.mock_client.config = {"start_date": "2024-01-01T00:00:00Z"}
+        self.stream = ConcreteIncremental(
+            client=self.mock_client, catalog=_make_catalog()
+        )
+
+    def test_get_bookmark_returns_start_date_when_no_bookmark_in_state(self):
+        state = {}
+        result = self.stream.get_bookmark(state, "test_stream")
+        self.assertEqual(result, "2024-01-01T00:00:00Z")
+
+    def test_get_bookmark_returns_existing_bookmark(self):
+        state = {
+            "bookmarks": {
+                "test_stream": {"updated_at": "2024-06-01T00:00:00Z"}
+            }
+        }
+        result = self.stream.get_bookmark(state, "test_stream")
+        self.assertEqual(result, "2024-06-01T00:00:00Z")
+
+    def test_write_bookmark_uses_max(self):
+        state = {
+            "bookmarks": {
+                "test_stream": {"updated_at": "2024-03-01T00:00:00Z"}
+            }
+        }
+        # New value earlier than existing — existing should win
+        result = self.stream.write_bookmark(
+            state, "test_stream", value="2024-01-01T00:00:00Z"
+        )
+        self.assertEqual(
+            result["bookmarks"]["test_stream"]["updated_at"],
+            "2024-03-01T00:00:00Z",
+        )
+
+    def test_write_bookmark_advances_bookmark(self):
+        state = {
+            "bookmarks": {
+                "test_stream": {"updated_at": "2024-01-01T00:00:00Z"}
+            }
+        }
+        # New value later than existing — new value should win
+        result = self.stream.write_bookmark(
+            state, "test_stream", value="2024-06-01T00:00:00Z"
+        )
+        self.assertEqual(
+            result["bookmarks"]["test_stream"]["updated_at"],
+            "2024-06-01T00:00:00Z",
+        )
+
+    def test_write_bookmark_noop_when_no_replication_keys(self):
+        self.stream.replication_keys = None
+        state = {}
+        result = self.stream.write_bookmark(state, "test_stream", value="2024-01-01")
+        self.assertEqual(result, state)
+
+
+# ---------------------------------------------------------------------------
+# ChildBaseStream
+# ---------------------------------------------------------------------------
+
+class TestChildBaseStream(unittest.TestCase):
+
+    @patch("tap_harvest.streams.abstracts.metadata.to_map", return_value={})
+    def setUp(self, _):
+        self.mock_client = MagicMock()
+        self.mock_client.base_url = "https://api.harvestapp.com/v2"
+        self.mock_client.config = {"start_date": "2024-01-01T00:00:00Z"}
+        self.stream = ConcreteChild(
+            client=self.mock_client, catalog=_make_catalog()
+        )
+
+    def test_get_url_endpoint_formats_parent_id(self):
+        parent_obj = {"id": 123}
+        url = self.stream.get_url_endpoint(parent_obj)
+        self.assertIn("123", url)
+
+    def test_get_bookmark_is_singleton(self):
+        """Second call to get_bookmark returns cached value without re-reading state."""
+        state = {"bookmarks": {"child_stream": {"updated_at": "2024-05-01T00:00:00Z"}}}
+        first = self.stream.get_bookmark(state, "child_stream")
+        # Mutate state so a fresh read would differ
+        state["bookmarks"]["child_stream"]["updated_at"] = "2025-01-01T00:00:00Z"
+        second = self.stream.get_bookmark(state, "child_stream")
+        self.assertEqual(first, second)

--- a/tests/unittests/test_sync.py
+++ b/tests/unittests/test_sync.py
@@ -1,0 +1,146 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from tap_harvest.sync import sync, update_currently_syncing
+
+
+class TestUpdateCurrentlySyncing(unittest.TestCase):
+    """Tests for update_currently_syncing()."""
+
+    @patch("tap_harvest.sync.singer.write_state")
+    @patch("tap_harvest.sync.singer.set_currently_syncing")
+    @patch("tap_harvest.sync.singer.get_currently_syncing", return_value=None)
+    def test_sets_currently_syncing(
+        self, mock_get, mock_set, mock_write
+    ):
+        """Sets currently_syncing in state when stream_name is provided."""
+        state = {}
+        update_currently_syncing(state, "my_stream")
+        mock_set.assert_called_once_with(state, "my_stream")
+        mock_write.assert_called_once_with(state)
+
+    @patch("tap_harvest.sync.singer.write_state")
+    @patch("tap_harvest.sync.singer.set_currently_syncing")
+    @patch("tap_harvest.sync.singer.get_currently_syncing", return_value="old_stream")
+    def test_clears_currently_syncing_when_stream_none(
+        self, mock_get, mock_set, mock_write
+    ):
+        """Removes currently_syncing from state when stream_name is None."""
+        state = {"currently_syncing": "old_stream"}
+        update_currently_syncing(state, None)
+        self.assertNotIn("currently_syncing", state)
+        mock_write.assert_called_once_with(state)
+
+    @patch("tap_harvest.sync.singer.write_state")
+    @patch("tap_harvest.sync.singer.set_currently_syncing")
+    @patch("tap_harvest.sync.singer.get_currently_syncing", return_value=None)
+    def test_no_key_deletion_when_already_empty(
+        self, mock_get, mock_set, mock_write
+    ):
+        """Does not raise if currently_syncing is not present and stream is None."""
+        state = {}
+        # when stream_name=None and get_currently_syncing returns None, no deletion
+        update_currently_syncing(state, None)
+        mock_write.assert_called_once_with(state)
+
+
+class TestSync(unittest.TestCase):
+    """Tests for sync()."""
+
+    def _make_catalog(self, stream_names):
+        """Build a minimal mock catalog with the given selected streams."""
+        catalog = MagicMock()
+
+        stream_entries = []
+        for name in stream_names:
+            entry = MagicMock()
+            entry.stream = name
+            stream_entries.append(entry)
+
+        catalog.get_selected_streams.return_value = stream_entries
+
+        def get_stream(name):
+            mock_entry = MagicMock()
+            mock_entry.stream = name
+            return mock_entry
+
+        catalog.get_stream.side_effect = get_stream
+        return catalog
+
+    @patch("tap_harvest.sync.update_currently_syncing")
+    @patch("tap_harvest.sync.write_schema")
+    @patch("tap_harvest.sync.STREAMS")
+    @patch("tap_harvest.sync.singer.get_currently_syncing", return_value=None)
+    def test_sync_simple_stream(
+        self, mock_gcs, mock_streams, mock_write_schema, mock_update_cs
+    ):
+        """Syncs a non-parent stream end-to-end."""
+        mock_client = MagicMock()
+        config = {"start_date": "2024-01-01T00:00:00Z"}
+        catalog = self._make_catalog(["clients"])
+        state = {}
+
+        mock_stream_instance = MagicMock()
+        mock_stream_instance.parent = None
+        mock_stream_instance.sync.return_value = 5
+        mock_streams.__getitem__.return_value = MagicMock(
+            return_value=mock_stream_instance
+        )
+        mock_streams.__contains__ = lambda self_, item: True
+
+        with patch("tap_harvest.sync.singer.Transformer") as mock_transformer_cls:
+            mock_transformer = MagicMock()
+            mock_transformer.__enter__ = MagicMock(return_value=mock_transformer)
+            mock_transformer.__exit__ = MagicMock(return_value=False)
+            mock_transformer_cls.return_value = mock_transformer
+
+            sync(mock_client, config, catalog, state)
+
+        mock_write_schema.assert_called_once()
+        mock_stream_instance.sync.assert_called_once_with(
+            state=state, transformer=mock_transformer
+        )
+
+    @patch("tap_harvest.sync.update_currently_syncing")
+    @patch("tap_harvest.sync.write_schema")
+    @patch("tap_harvest.sync.STREAMS")
+    @patch("tap_harvest.sync.singer.get_currently_syncing", return_value=None)
+    def test_sync_skips_child_stream_and_appends_parent(
+        self, mock_gcs, mock_streams, mock_write_schema, mock_update_cs
+    ):
+        """Child streams are deferred; their parent is added to the sync list."""
+        mock_client = MagicMock()
+        config = {"start_date": "2024-01-01T00:00:00Z"}
+        catalog = self._make_catalog(["time_entry_external_reference"])
+        state = {}
+
+        mock_stream_instance = MagicMock()
+        mock_stream_instance.parent = "time_entries"
+        mock_streams.__getitem__.return_value = MagicMock(
+            return_value=mock_stream_instance
+        )
+        mock_streams.__contains__ = lambda self_, item: True
+
+        # Stream for time_entries (the parent)
+        mock_parent_instance = MagicMock()
+        mock_parent_instance.parent = None
+        mock_parent_instance.sync.return_value = 10
+
+        def stream_factory(stream_name):
+            if stream_name == "time_entries":
+                return mock_parent_instance
+            return mock_stream_instance
+
+        mock_streams.__getitem__.side_effect = lambda name: MagicMock(
+            return_value=stream_factory(name)
+        )
+
+        with patch("tap_harvest.sync.singer.Transformer") as mock_transformer_cls:
+            mock_transformer = MagicMock()
+            mock_transformer.__enter__ = MagicMock(return_value=mock_transformer)
+            mock_transformer.__exit__ = MagicMock(return_value=False)
+            mock_transformer_cls.return_value = mock_transformer
+
+            sync(mock_client, config, catalog, state)
+
+        # Parent stream should have been synced
+        mock_parent_instance.sync.assert_called_once()


### PR DESCRIPTION
# Description of change
This PR updates the tap’s packaged dependency version (`singer-python`) and bumps the tap version, while adding a new unit test suite to validate key behaviors in sync, discovery, schema loading, and stream utilities.

Jira Ticket: [SAC-28722](https://qlik-dev.atlassian.net/browse/SAC-28722)

**Changes:**
- Bump `tap-harvest` version to `3.1.0` and update `singer-python` dependency pin from `6.1.1` → `6.8.0`.
- Add unit tests covering `sync()`, `update_currently_syncing()`, schema helpers, discovery output, and stream base-class helpers/bookmarks.

| File | Description |
| ---- | ----------- |
| `setup.py` | Bumps package version and updates `singer-python` pin. |
| `tests/unittests/test_sync.py` | Adds unit tests for sync flow and currently-syncing state handling. |
| `tests/unittests/test_streams.py` | Adds unit tests for stream helper methods and bookmark behavior. |
| `tests/unittests/test_schema.py` | Adds unit tests for schema pathing, reference loading, schema generation, and schema writing recursion. |
| `tests/unittests/test_init.py` | Adds unit tests for `do_discover()` output/logging and required config keys. |
| `tests/unittests/test_discover.py` | Adds unit tests for catalog discovery construction. |


# Manual QA steps
 - Run unit tests and confirm all 48 pass: `python -m pytest tests/unittests/ -v`
 - Run discovery mode and confirm 25 streams are returned: `tap-harvest --config config.json --discover`
 - Run a sync against at least one stream (e.g. `roles`) and verify valid `SCHEMA`, `RECORD`, and `STATE` Singer messages are emitted with no errors.

 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
