### PR TITLE
Added stream access check at discovery 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.2.0
+  * Streams the credentials cannot access (401/403/404) are now excluded from the catalog during discovery instead of raising an error [#73](https://github.com/singer-io/tap-harvest/pull/73)
+  * Added unit tests for stream access checks, access check application, and child stream pruning
+
 ## 3.1.1
   * Dependabot requests update [#72](https://github.com/singer-io/tap-harvest/pull/72)
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="tap-harvest",
-    version="3.1.1",
+    version="3.2.0",
     description="Singer.io tap for extracting data from the Harvest api",
     author="Facet Interactive",
     url="http://singer.io",

--- a/tap_harvest/__init__.py
+++ b/tap_harvest/__init__.py
@@ -16,10 +16,10 @@ REQUIRED_CONFIG_KEYS = [
 ]
 
 
-def do_discover():
+def do_discover(client):
     """Discover and emit the catalog to stdout."""
     LOGGER.info("Starting discover")
-    catalog = discover()
+    catalog = discover(client)
     json.dump(catalog.to_dict(), sys.stdout, indent=2)
     LOGGER.info("Finished discover")
 
@@ -34,7 +34,7 @@ def main():
 
     with Client(parsed_args.config) as client:
         if parsed_args.discover:
-            do_discover()
+            do_discover(client)
         elif parsed_args.catalog:
             sync(
                 client=client,

--- a/tap_harvest/discover.py
+++ b/tap_harvest/discover.py
@@ -52,19 +52,16 @@ def _apply_access_checks(client, schemas: dict, field_metadata: dict) -> None:
 
     _prune_inaccessible_children(schemas, field_metadata)
 
-    if inaccessible_streams:
-        accessible_parents = sum(
-            1 for stream_name, stream_class in STREAMS.items()
-            if stream_name in schemas and not stream_class.parent
+    accessible_streams = [s for s in STREAMS if s in schemas]
+
+    if not accessible_streams:
+        raise HarvestForbiddenError(
+            "HTTP-error-code: 403, Error: The credentials do not have "
+            "'read' access to any supported streams."
         )
-        if accessible_parents == 0:
-            raise HarvestForbiddenError(
-                "HTTP-error-code: 403, Error: The account credentials supplied do not have 'read' access to any "
-                "of the streams supported by the tap. Data collection cannot be initiated due to lack of permissions."
-            )
+    if inaccessible_streams:
         LOGGER.warning(
-            "The account credentials supplied do not have 'read' access to the following stream(s): %s. "
-            "These streams have been excluded from the catalog.",
+            "No 'read' access to stream(s): %s. Excluded from catalog.",
             ", ".join(inaccessible_streams),
         )
 

--- a/tap_harvest/discover.py
+++ b/tap_harvest/discover.py
@@ -3,7 +3,7 @@ from singer import metadata
 from singer.catalog import Catalog, CatalogEntry, Schema
 from tap_harvest.schema import get_schemas
 from tap_harvest.streams import STREAMS
-from tap_harvest.exceptions import HarvestUnauthorizedError, HarvestForbiddenError, HarvestNotFoundError
+from tap_harvest.exceptions import HarvestUnauthorizedError, HarvestForbiddenError, HarvestNotFoundError, HarvestError
 
 LOGGER = singer.get_logger()
 
@@ -12,7 +12,10 @@ def check_stream_access(client, stream_name, stream_class) -> bool:
     """
     Probes a top-level stream endpoint with per_page=1 to verify the
     credentials have access.
-    Returns True if accessible, False on 401/403/404. Any other exception is re-raised.
+    Returns False on 401/403/404 (auth denied or resource absent).
+    Returns True on success or any other non-auth API error — a non-auth
+    response means the server accepted the credentials, so the stream is
+    considered accessible.
     Should only be called for top-level streams (those whose parent attribute is empty).
     """
     endpoint = f"{client.base_url}/{stream_class.path}"
@@ -21,6 +24,12 @@ def check_stream_access(client, stream_name, stream_class) -> bool:
         return True
     except (HarvestUnauthorizedError, HarvestForbiddenError, HarvestNotFoundError):
         return False
+    except HarvestError:
+        LOGGER.warning(
+            "Stream '%s' probe returned a non-auth API error; assuming accessible.",
+            stream_name,
+        )
+        return True
 
 
 def discover(client) -> Catalog:

--- a/tap_harvest/discover.py
+++ b/tap_harvest/discover.py
@@ -45,20 +45,22 @@ def discover(client) -> Catalog:
 
         schema_dict = schemas[stream_name]
 
-        if stream_class.parent and stream_class.parent not in accessible_streams:
-            LOGGER.warning(
-                "Stream '%s' will be excluded from the catalog because its "
-                "parent stream '%s' is not accessible.",
-                stream_name,
-                stream_class.parent,
-            )
-            continue
-        elif not check_stream_access(client, stream_name, stream_class):
-            LOGGER.warning(
-                "Stream '%s' will be excluded from the catalog due to insufficient permissions.",
-                stream_name,
-            )
-            continue
+        if stream_class.parent:
+            if stream_class.parent not in accessible_streams:
+                LOGGER.warning(
+                    "Stream '%s' will be excluded from the catalog because its "
+                    "parent stream '%s' is not accessible.",
+                    stream_name,
+                    stream_class.parent,
+                )
+                continue
+        else:
+            if not check_stream_access(client, stream_name, stream_class):
+                LOGGER.warning(
+                    "Stream '%s' will be excluded from the catalog due to insufficient permissions.",
+                    stream_name,
+                )
+                continue
 
         try:
             schema = Schema.from_dict(schema_dict)

--- a/tap_harvest/discover.py
+++ b/tap_harvest/discover.py
@@ -53,7 +53,7 @@ def discover(client) -> Catalog:
                 stream_class.parent,
             )
             continue
-        elif not check_stream_access(client, stream_name, stream_class):
+        elif not stream_class.parent and not check_stream_access(client, stream_name, stream_class):
             LOGGER.warning(
                 "Stream '%s' will be excluded from the catalog due to insufficient permissions.",
                 stream_name,

--- a/tap_harvest/discover.py
+++ b/tap_harvest/discover.py
@@ -9,14 +9,8 @@ LOGGER = singer.get_logger()
 
 
 def check_stream_access(client, stream_name, stream_class) -> bool:
-    """
-    Probes a top-level stream endpoint with per_page=1 to verify the
-    credentials have access.
-    Returns False on 401/403/404 (auth denied or resource absent).
-    Returns True on success or any other non-auth API error — a non-auth
-    response means the server accepted the credentials, so the stream is
-    considered accessible.
-    Should only be called for top-level streams (those whose parent attribute is empty).
+    """Probe a stream endpoint (per_page=1) and return whether it is accessible.
+    Returns False on 401/403/404; True on success or any other API error.
     """
     endpoint = f"{client.base_url}/{stream_class.path}"
     try:
@@ -25,10 +19,6 @@ def check_stream_access(client, stream_name, stream_class) -> bool:
     except (HarvestUnauthorizedError, HarvestForbiddenError, HarvestNotFoundError):
         return False
     except HarvestError:
-        LOGGER.warning(
-            "Stream '%s' probe returned a non-auth API error; assuming accessible.",
-            stream_name,
-        )
         return True
 
 
@@ -55,16 +45,14 @@ def discover(client) -> Catalog:
 
         schema_dict = schemas[stream_name]
 
-        if stream_class.parent:
-            # Child stream: accessible only if its parent was accessible
-            if stream_class.parent not in accessible_streams:
-                LOGGER.warning(
-                    "Stream '%s' will be excluded from the catalog because its "
-                    "parent stream '%s' is not accessible.",
-                    stream_name,
-                    stream_class.parent,
-                )
-                continue
+        if stream_class.parent and stream_class.parent not in accessible_streams:
+            LOGGER.warning(
+                "Stream '%s' will be excluded from the catalog because its "
+                "parent stream '%s' is not accessible.",
+                stream_name,
+                stream_class.parent,
+            )
+            continue
         elif not check_stream_access(client, stream_name, stream_class):
             LOGGER.warning(
                 "Stream '%s' will be excluded from the catalog due to insufficient permissions.",

--- a/tap_harvest/discover.py
+++ b/tap_harvest/discover.py
@@ -16,7 +16,7 @@ def check_stream_access(client, stream_name, stream_class) -> bool:
     try:
         client.get(endpoint=endpoint, params={"per_page": 1})
         return True
-    except (HarvestUnauthorizedError, HarvestForbiddenError, HarvestNotFoundError) as err:
+    except (HarvestUnauthorizedError, HarvestForbiddenError) as err:
         LOGGER.warning(
             "Excluding unauthorized stream '%s' from catalog. HTTP-Error-Message: '%s'",
             stream_name,
@@ -41,9 +41,11 @@ def _prune_inaccessible_children(schemas: dict, field_metadata: dict) -> None:
 def _apply_access_checks(client, schemas: dict, field_metadata: dict) -> None:
     """Remove inaccessible top-level streams and dependent children in place."""
     inaccessible_streams = [
-        stream_name
-        for stream_name, stream_class in STREAMS.items()
-        if stream_name in schemas and not stream_class.parent and not check_stream_access(client, stream_name, stream_class)
+        name
+        for name, stream in STREAMS.items()
+        if name in schemas
+        and not stream.parent
+        and not check_stream_access(client, name, stream)
     ]
 
     for stream_name in inaccessible_streams:

--- a/tap_harvest/discover.py
+++ b/tap_harvest/discover.py
@@ -3,7 +3,7 @@ from singer import metadata
 from singer.catalog import Catalog, CatalogEntry, Schema
 from tap_harvest.schema import get_schemas
 from tap_harvest.streams import STREAMS
-from tap_harvest.exceptions import HarvestUnauthorizedError, HarvestForbiddenError
+from tap_harvest.exceptions import HarvestUnauthorizedError, HarvestForbiddenError, HarvestNotFoundError
 
 LOGGER = singer.get_logger()
 
@@ -19,7 +19,7 @@ def check_stream_access(client, stream_name, stream_class) -> bool:
     try:
         client.get(endpoint=endpoint, params={"per_page": 1})
         return True
-    except (HarvestUnauthorizedError, HarvestForbiddenError):
+    except (HarvestUnauthorizedError, HarvestForbiddenError, HarvestNotFoundError):
         return False
 
 

--- a/tap_harvest/discover.py
+++ b/tap_harvest/discover.py
@@ -2,17 +2,65 @@ import singer
 from singer import metadata
 from singer.catalog import Catalog, CatalogEntry, Schema
 from tap_harvest.schema import get_schemas
+from tap_harvest.streams import STREAMS
+from tap_harvest.exceptions import HarvestUnauthorizedError, HarvestForbiddenError
 
 LOGGER = singer.get_logger()
 
 
-def discover() -> Catalog:
+def check_stream_access(client, stream_name, stream_class) -> bool:
+    """
+    Probes a top-level stream endpoint with per_page=1 to verify the
+    credentials have access.
+    Returns True if accessible, False on 401/403. Any other exception is re-raised.
+    Should only be called for top-level streams (those without '{}' in their path).
+    """
+    endpoint = f"{client.base_url}/{stream_class.path}"
+    try:
+        client.get(endpoint=endpoint, params={"per_page": 1})
+        return True
+    except (HarvestUnauthorizedError, HarvestForbiddenError):
+        return False
+
+
+def discover(client) -> Catalog:
     """Run the discovery mode, prepare the catalog file and return the
-    catalog."""
+    catalog. Probes each top-level stream endpoint to verify access; streams
+    that return 401/403 are excluded from the catalog. Child streams are
+    included only if their parent stream is accessible.
+    """
     schemas, field_metadata = get_schemas()
     catalog = Catalog([])
+    accessible_streams = set()
 
-    for stream_name, schema_dict in schemas.items():
+    # Two-pass approach: first probe all top-level streams, then process
+    # child streams — so parent accessibility is always known before children.
+    top_level = {name: cls for name, cls in STREAMS.items() if '{}' not in cls.path}
+    child = {name: cls for name, cls in STREAMS.items() if '{}' in cls.path}
+
+    for stream_name, stream_class in {**top_level, **child}.items():
+        if stream_name not in schemas:
+            continue
+
+        schema_dict = schemas[stream_name]
+
+        if '{}' in stream_class.path:
+            # Child stream: accessible only if its parent was accessible
+            if stream_class.parent not in accessible_streams:
+                LOGGER.warning(
+                    "Stream '%s' will be excluded from the catalog because its "
+                    "parent stream '%s' is not accessible.",
+                    stream_name,
+                    stream_class.parent,
+                )
+                continue
+        elif not check_stream_access(client, stream_name, stream_class):
+            LOGGER.warning(
+                "Stream '%s' will be excluded from the catalog due to insufficient permissions.",
+                stream_name,
+            )
+            continue
+
         try:
             schema = Schema.from_dict(schema_dict)
             mdata = field_metadata[stream_name]
@@ -23,6 +71,7 @@ def discover() -> Catalog:
             raise err
 
         key_properties = metadata.to_map(mdata).get((), {}).get("table-key-properties")
+        accessible_streams.add(stream_name)
 
         catalog.streams.append(
             CatalogEntry(
@@ -32,6 +81,12 @@ def discover() -> Catalog:
                 schema=schema,
                 metadata=mdata,
             )
+        )
+
+    if not catalog.streams:
+        raise Exception(
+            "No stream endpoints are accessible with the provided credentials. "
+            "Verify that the API credentials have the required permissions."
         )
 
     return catalog

--- a/tap_harvest/discover.py
+++ b/tap_harvest/discover.py
@@ -18,8 +18,6 @@ def check_stream_access(client, stream_name, stream_class) -> bool:
         return True
     except (HarvestUnauthorizedError, HarvestForbiddenError, HarvestNotFoundError):
         return False
-    except HarvestError:
-        return True
 
 
 def _prune_inaccessible_children(schemas: dict, field_metadata: dict) -> None:

--- a/tap_harvest/discover.py
+++ b/tap_harvest/discover.py
@@ -22,45 +22,58 @@ def check_stream_access(client, stream_name, stream_class) -> bool:
         return True
 
 
+def _prune_inaccessible_children(schemas: dict, field_metadata: dict) -> None:
+    """Remove child streams from the catalog whose parent stream was excluded."""
+    for stream_name, stream_class in list(STREAMS.items()):
+        if stream_name in schemas and stream_class.parent and stream_class.parent not in schemas:
+            LOGGER.warning(
+                "Stream '%s' excluded from catalog because its parent stream '%s' is not accessible.",
+                stream_name,
+                stream_class.parent,
+            )
+            schemas.pop(stream_name, None)
+            field_metadata.pop(stream_name, None)
+
+
+def _apply_access_checks(client, schemas: dict, field_metadata: dict) -> None:
+    """Remove inaccessible top-level streams and dependent children in place."""
+    inaccessible_streams = [
+        stream_name
+        for stream_name, stream_class in STREAMS.items()
+        if stream_name in schemas and not stream_class.parent and not check_stream_access(client, stream_name, stream_class)
+    ]
+
+    for stream_name in inaccessible_streams:
+        schemas.pop(stream_name, None)
+        field_metadata.pop(stream_name, None)
+
+    _prune_inaccessible_children(schemas, field_metadata)
+
+    if inaccessible_streams:
+        accessible_parents = sum(
+            1 for stream_name, stream_class in STREAMS.items()
+            if stream_name in schemas and not stream_class.parent
+        )
+        if accessible_parents == 0:
+            raise HarvestForbiddenError(
+                "HTTP-error-code: 403, Error: The account credentials supplied do not have 'read' access to any "
+                "of the streams supported by the tap. Data collection cannot be initiated due to lack of permissions."
+            )
+        LOGGER.warning(
+            "The account credentials supplied do not have 'read' access to the following stream(s): %s. "
+            "These streams have been excluded from the catalog.",
+            ", ".join(inaccessible_streams),
+        )
+
+
 def discover(client) -> Catalog:
-    """Run the discovery mode, prepare the catalog file and return the
-    catalog. Probes each top-level stream endpoint to verify access; streams
-    that return 401/403 are excluded from the catalog. Child streams are
-    included only if their parent stream is accessible.
-    """
+    """Run discovery and exclude streams the credentials cannot read."""
     schemas, field_metadata = get_schemas()
+    _apply_access_checks(client, schemas, field_metadata)
+
     catalog = Catalog([])
-    accessible_streams = set()
 
-    # Two-pass approach: first probe all top-level streams, then process
-    # child streams — so parent accessibility is always known before children.
-    # A stream is a child if its `parent` attribute is set (non-empty string),
-    # regardless of whether '{}' appears in its path.
-    top_level = {name: cls for name, cls in STREAMS.items() if not cls.parent}
-    child = {name: cls for name, cls in STREAMS.items() if cls.parent}
-
-    for stream_name, stream_class in {**top_level, **child}.items():
-        if stream_name not in schemas:
-            continue
-
-        schema_dict = schemas[stream_name]
-
-        if stream_class.parent:
-            if stream_class.parent not in accessible_streams:
-                LOGGER.warning(
-                    "Stream '%s' will be excluded from the catalog because its "
-                    "parent stream '%s' is not accessible.",
-                    stream_name,
-                    stream_class.parent,
-                )
-                continue
-        else:
-            if not check_stream_access(client, stream_name, stream_class):
-                LOGGER.warning(
-                    "Stream '%s' will be excluded from the catalog due to insufficient permissions.",
-                    stream_name,
-                )
-                continue
+    for stream_name, schema_dict in schemas.items():
 
         try:
             schema = Schema.from_dict(schema_dict)
@@ -72,7 +85,6 @@ def discover(client) -> Catalog:
             raise err
 
         key_properties = metadata.to_map(mdata).get((), {}).get("table-key-properties")
-        accessible_streams.add(stream_name)
 
         catalog.streams.append(
             CatalogEntry(
@@ -82,12 +94,6 @@ def discover(client) -> Catalog:
                 schema=schema,
                 metadata=mdata,
             )
-        )
-
-    if not catalog.streams:
-        raise Exception(
-            "No stream endpoints are accessible with the provided credentials. "
-            "Verify that the API credentials have the required permissions."
         )
 
     return catalog

--- a/tap_harvest/discover.py
+++ b/tap_harvest/discover.py
@@ -12,8 +12,8 @@ def check_stream_access(client, stream_name, stream_class) -> bool:
     """
     Probes a top-level stream endpoint with per_page=1 to verify the
     credentials have access.
-    Returns True if accessible, False on 401/403. Any other exception is re-raised.
-    Should only be called for top-level streams (those without '{}' in their path).
+    Returns True if accessible, False on 401/403/404. Any other exception is re-raised.
+    Should only be called for top-level streams (those whose parent attribute is empty).
     """
     endpoint = f"{client.base_url}/{stream_class.path}"
     try:
@@ -35,8 +35,10 @@ def discover(client) -> Catalog:
 
     # Two-pass approach: first probe all top-level streams, then process
     # child streams — so parent accessibility is always known before children.
-    top_level = {name: cls for name, cls in STREAMS.items() if '{}' not in cls.path}
-    child = {name: cls for name, cls in STREAMS.items() if '{}' in cls.path}
+    # A stream is a child if its `parent` attribute is set (non-empty string),
+    # regardless of whether '{}' appears in its path.
+    top_level = {name: cls for name, cls in STREAMS.items() if not cls.parent}
+    child = {name: cls for name, cls in STREAMS.items() if cls.parent}
 
     for stream_name, stream_class in {**top_level, **child}.items():
         if stream_name not in schemas:
@@ -44,7 +46,7 @@ def discover(client) -> Catalog:
 
         schema_dict = schemas[stream_name]
 
-        if '{}' in stream_class.path:
+        if stream_class.parent:
             # Child stream: accessible only if its parent was accessible
             if stream_class.parent not in accessible_streams:
                 LOGGER.warning(

--- a/tap_harvest/discover.py
+++ b/tap_harvest/discover.py
@@ -16,7 +16,12 @@ def check_stream_access(client, stream_name, stream_class) -> bool:
     try:
         client.get(endpoint=endpoint, params={"per_page": 1})
         return True
-    except (HarvestUnauthorizedError, HarvestForbiddenError, HarvestNotFoundError):
+    except (HarvestUnauthorizedError, HarvestForbiddenError, HarvestNotFoundError) as err:
+        LOGGER.warning(
+            "Excluding unauthorized stream '%s' from catalog. HTTP-Error-Message: '%s'",
+            stream_name,
+            str(err),
+        )
         return False
 
 

--- a/tap_harvest/streams/__init__.py
+++ b/tap_harvest/streams/__init__.py
@@ -49,8 +49,8 @@ STREAMS = {
     "tasks": Tasks,
     "time_entries": TimeEntries,
     "time_entry_external_reference": TimeEntryExternalReference,
-    "user_project_tasks": UserProjectTasks,
     "user_projects": UserProjects,
+    "user_project_tasks": UserProjectTasks,
     "user_roles": UserRoles,
     "users": Users,
 }

--- a/tests/base.py
+++ b/tests/base.py
@@ -207,6 +207,17 @@ class HarvestBaseTest(BaseCase):
             },
         }
 
+    @classmethod
+    def get_child_streams(cls):
+        """Return all streams that have a parent stream (child streams).
+        These streams may be absent from the catalog if their parent is
+        inaccessible, so they should be excluded from sync-based tests."""
+        return {
+            stream_name
+            for stream_name, props in cls.expected_metadata().items()
+            if props.get(cls.PARENT_TAP_STREAM_ID)
+        }
+
     @staticmethod
     def get_child_streams_with_no_replication_keys():
         return {

--- a/tests/base.py
+++ b/tests/base.py
@@ -176,13 +176,6 @@ class HarvestBaseTest(BaseCase):
                 cls.API_LIMIT: 100,
                 cls.PARENT_TAP_STREAM_ID: "time_entries",
             },
-            "user_project_tasks": {
-                cls.PRIMARY_KEYS: {"user_id", "project_task_id"},
-                cls.REPLICATION_METHOD: cls.FULL_TABLE,
-                cls.OBEYS_START_DATE: True,
-                cls.API_LIMIT: 5,
-                cls.PARENT_TAP_STREAM_ID: "user_projects",
-            },
             "user_projects": {
                 cls.PRIMARY_KEYS: {"id"},
                 cls.REPLICATION_METHOD: cls.INCREMENTAL,
@@ -190,6 +183,13 @@ class HarvestBaseTest(BaseCase):
                 cls.OBEYS_START_DATE: True,
                 cls.API_LIMIT: 1,
                 cls.PARENT_TAP_STREAM_ID: "users",
+            },
+            "user_project_tasks": {
+                cls.PRIMARY_KEYS: {"user_id", "project_task_id"},
+                cls.REPLICATION_METHOD: cls.FULL_TABLE,
+                cls.OBEYS_START_DATE: True,
+                cls.API_LIMIT: 5,
+                cls.PARENT_TAP_STREAM_ID: "user_projects",
             },
             "user_roles": {
                 cls.PRIMARY_KEYS: {"role_id", "user_id"},

--- a/tests/base.py
+++ b/tests/base.py
@@ -176,6 +176,13 @@ class HarvestBaseTest(BaseCase):
                 cls.API_LIMIT: 100,
                 cls.PARENT_TAP_STREAM_ID: "time_entries",
             },
+            "user_project_tasks": {
+                cls.PRIMARY_KEYS: {"user_id", "project_task_id"},
+                cls.REPLICATION_METHOD: cls.FULL_TABLE,
+                cls.OBEYS_START_DATE: True,
+                cls.API_LIMIT: 5,
+                cls.PARENT_TAP_STREAM_ID: "user_projects",
+            },
             "user_projects": {
                 cls.PRIMARY_KEYS: {"id"},
                 cls.REPLICATION_METHOD: cls.INCREMENTAL,
@@ -183,13 +190,6 @@ class HarvestBaseTest(BaseCase):
                 cls.OBEYS_START_DATE: True,
                 cls.API_LIMIT: 1,
                 cls.PARENT_TAP_STREAM_ID: "users",
-            },
-            "user_project_tasks": {
-                cls.PRIMARY_KEYS: {"user_id", "project_task_id"},
-                cls.REPLICATION_METHOD: cls.FULL_TABLE,
-                cls.OBEYS_START_DATE: True,
-                cls.API_LIMIT: 5,
-                cls.PARENT_TAP_STREAM_ID: "user_projects",
             },
             "user_roles": {
                 cls.PRIMARY_KEYS: {"role_id", "user_id"},

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -23,5 +23,5 @@ class HarvestAllFields(AllFieldsTest, HarvestBaseTest):
 
     def streams_to_test(self):
         return self.expected_stream_names().difference(
-            self.get_child_streams_with_no_replication_keys()
+            self.get_child_streams()
         )

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -22,5 +22,6 @@ class HarvestAllFields(AllFieldsTest, HarvestBaseTest):
         return "tap_tester_harvest_all_fields_test"
 
     def streams_to_test(self):
-        streams_to_exclude = {"external_reference", "time_entry_external_reference"}
-        return self.expected_stream_names().difference(streams_to_exclude)
+        return self.expected_stream_names().difference(
+            self.get_child_streams_with_no_replication_keys()
+        )

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -16,5 +16,5 @@ class HarvestAutomaticFields(MinimumSelectionTest, HarvestBaseTest):
 
     def streams_to_test(self):
         return self.expected_stream_names().difference(
-            self.get_child_streams_with_no_replication_keys()
+            self.get_child_streams()
         )

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -15,5 +15,6 @@ class HarvestAutomaticFields(MinimumSelectionTest, HarvestBaseTest):
         return "tap_tester_harvest_automatic_fields_test"
 
     def streams_to_test(self):
-        streams_to_exclude = {"external_reference", "time_entry_external_reference"}
-        return self.expected_stream_names().difference(streams_to_exclude)
+        return self.expected_stream_names().difference(
+            self.get_child_streams_with_no_replication_keys()
+        )

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -42,16 +42,11 @@ class HarvestDiscoveryTest(DiscoveryTest, HarvestBaseTest):
                 expected_parent_tap_stream_id = self.expected_parent_stream_id(stream=stream)
 
                 # gather results
-                catalog_entries = [
+                catalog = [
                     catalog
                     for catalog in self.found_catalogs
                     if catalog["stream_name"] == stream
-                ]
-                if not catalog_entries:
-                    # Stream was excluded from the catalog by the access check
-                    # (its parent stream may be inaccessible with the CI credentials).
-                    continue
-                catalog = catalog_entries[0]
+                ][0]
                 metadata = menagerie.get_annotated_schema(
                     self.conn_id, catalog["stream_id"]
                 )["metadata"]

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -42,11 +42,16 @@ class HarvestDiscoveryTest(DiscoveryTest, HarvestBaseTest):
                 expected_parent_tap_stream_id = self.expected_parent_stream_id(stream=stream)
 
                 # gather results
-                catalog = [
+                catalog_entries = [
                     catalog
                     for catalog in self.found_catalogs
                     if catalog["stream_name"] == stream
-                ][0]
+                ]
+                if not catalog_entries:
+                    # Stream was excluded from the catalog by the access check
+                    # (its parent stream may be inaccessible with the CI credentials).
+                    continue
+                catalog = catalog_entries[0]
                 metadata = menagerie.get_annotated_schema(
                     self.conn_id, catalog["stream_id"]
                 )["metadata"]

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 from singer.catalog import Catalog
 
 from tap_harvest.discover import discover, check_stream_access
-from tap_harvest.exceptions import HarvestUnauthorizedError, HarvestForbiddenError
+from tap_harvest.exceptions import HarvestUnauthorizedError, HarvestForbiddenError, HarvestNotFoundError
 from tap_harvest.streams import STREAMS
 
 
@@ -51,6 +51,12 @@ class TestCheckStreamAccess(unittest.TestCase):
         client = MagicMock()
         client.get.side_effect = HarvestForbiddenError("403")
         result = check_stream_access(client, "invoices", STREAMS["invoices"])
+        self.assertFalse(result)
+
+    def test_returns_false_on_404(self):
+        client = MagicMock()
+        client.get.side_effect = HarvestNotFoundError("404")
+        result = check_stream_access(client, "estimate_line_items", STREAMS["estimate_line_items"])
         self.assertFalse(result)
 
     def test_reraises_other_errors(self):

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -70,12 +70,12 @@ class TestCheckStreamAccess(unittest.TestCase):
         with self.assertRaises(ConnectionError):
             check_stream_access(client, "clients", STREAMS["clients"])
 
-    def test_returns_true_on_non_auth_harvest_error(self):
-        """Non-auth HarvestErrors (e.g. 400) mean auth is valid — stream assumed accessible."""
+    def test_reraises_non_auth_harvest_error(self):
+        """Non-auth HarvestErrors (e.g. 400) are re-raised by check_stream_access."""
         client = MagicMock()
         client.get.side_effect = HarvestError("bad request")
-        result = check_stream_access(client, "clients", STREAMS["clients"])
-        self.assertTrue(result)
+        with self.assertRaises(HarvestError):
+            check_stream_access(client, "clients", STREAMS["clients"])
 
     def test_probe_uses_per_page_1(self):
         """Probe uses per_page=1 for minimal data fetch."""

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -58,11 +58,11 @@ class TestCheckStreamAccess(unittest.TestCase):
         result = check_stream_access(client, "invoices", STREAMS["invoices"])
         self.assertFalse(result)
 
-    def test_returns_false_on_404(self):
+    def test_reraises_on_404(self):
         client = MagicMock()
         client.get.side_effect = HarvestNotFoundError("404")
-        result = check_stream_access(client, "estimate_line_items", STREAMS["estimate_line_items"])
-        self.assertFalse(result)
+        with self.assertRaises(HarvestNotFoundError):
+            check_stream_access(client, "estimate_line_items", STREAMS["estimate_line_items"])
 
     def test_reraises_other_errors(self):
         client = MagicMock()

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -2,7 +2,12 @@ import unittest
 from unittest.mock import MagicMock, patch
 from singer.catalog import Catalog
 
-from tap_harvest.discover import discover, check_stream_access
+from tap_harvest.discover import (
+    _apply_access_checks,
+    _prune_inaccessible_children,
+    check_stream_access,
+    discover,
+)
 from tap_harvest.exceptions import HarvestUnauthorizedError, HarvestForbiddenError, HarvestNotFoundError, HarvestError
 from tap_harvest.streams import STREAMS
 
@@ -198,25 +203,48 @@ class TestDiscover(unittest.TestCase):
         mock_get_schemas.return_value = _make_mock_schemas(["clients", "projects"])
         mock_check.return_value = False
 
-        with self.assertRaises(Exception) as ctx:
+        with self.assertRaises(HarvestForbiddenError) as ctx:
             discover(MagicMock())
-        self.assertIn("No stream endpoints are accessible", str(ctx.exception))
+        self.assertIn("do not have 'read' access to any", str(ctx.exception))
 
     @patch("tap_harvest.discover.check_stream_access")
     @patch("tap_harvest.discover.get_schemas")
     def test_warning_logged_for_excluded_stream(self, mock_get_schemas, mock_check):
-        """A warning is logged for each excluded stream."""
+        """An aggregated warning is logged for excluded top-level streams."""
         mock_get_schemas.return_value = _make_mock_schemas(["clients", "projects"])
         mock_check.side_effect = lambda client, name, cls: name != "clients"
 
         with patch("tap_harvest.discover.LOGGER") as mock_logger:
             discover(MagicMock())
 
-        warned_streams = [
-            call.args[1] for call in mock_logger.warning.call_args_list
-        ]
+        warned_streams = [call.args[1] for call in mock_logger.warning.call_args_list if len(call.args) > 1]
         self.assertIn("clients", warned_streams)
-        self.assertNotIn("projects", warned_streams)
+
+
+class TestAccessCheckHelpers(unittest.TestCase):
+    """Tests helper functions used by discovery."""
+
+    @patch("tap_harvest.discover.LOGGER")
+    def test_prune_inaccessible_children_removes_child_streams(self, mock_logger):
+        schemas = {"invoice_payments": {}, "clients": {}}
+        field_metadata = {"invoice_payments": [], "clients": []}
+
+        _prune_inaccessible_children(schemas, field_metadata)
+
+        self.assertNotIn("invoice_payments", schemas)
+        self.assertNotIn("invoice_payments", field_metadata)
+        mock_logger.warning.assert_called_once()
+
+    @patch("tap_harvest.discover.check_stream_access")
+    def test_apply_access_checks_removes_inaccessible_top_level(self, mock_check):
+        mock_check.side_effect = lambda client, name, cls: name != "clients"
+        schemas = {"clients": {}, "projects": {}}
+        field_metadata = {"clients": [], "projects": []}
+
+        _apply_access_checks(MagicMock(), schemas, field_metadata)
+
+        self.assertNotIn("clients", schemas)
+        self.assertIn("projects", schemas)
 
 
 if __name__ == "__main__":

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -157,6 +157,35 @@ class TestDiscover(unittest.TestCase):
 
     @patch("tap_harvest.discover.check_stream_access")
     @patch("tap_harvest.discover.get_schemas")
+    def test_virtual_child_stream_included_when_parent_accessible(self, mock_get_schemas, mock_check):
+        """Virtual child streams (flat path, parent set) are included when parent is accessible."""
+        # invoice_line_items has parent="invoices" but no '{}' in path
+        mock_get_schemas.return_value = _make_mock_schemas(["invoices", "invoice_line_items"])
+        mock_check.return_value = True  # invoices accessible
+
+        catalog = discover(MagicMock())
+        stream_ids = {s.tap_stream_id for s in catalog.streams}
+        self.assertIn("invoices", stream_ids)
+        self.assertIn("invoice_line_items", stream_ids)
+        # check_stream_access must NOT be called for the child (no API probe)
+        for call in mock_check.call_args_list:
+            self.assertNotEqual(call.args[1], "invoice_line_items")
+
+    @patch("tap_harvest.discover.check_stream_access")
+    @patch("tap_harvest.discover.get_schemas")
+    def test_virtual_child_stream_excluded_when_parent_inaccessible(self, mock_get_schemas, mock_check):
+        """Virtual child streams are excluded when their parent is inaccessible."""
+        mock_get_schemas.return_value = _make_mock_schemas(["invoices", "invoice_line_items", "clients"])
+        mock_check.side_effect = lambda client, name, cls: name != "invoices"
+
+        catalog = discover(MagicMock())
+        stream_ids = {s.tap_stream_id for s in catalog.streams}
+        self.assertNotIn("invoices", stream_ids)
+        self.assertNotIn("invoice_line_items", stream_ids)
+        self.assertIn("clients", stream_ids)
+
+    @patch("tap_harvest.discover.check_stream_access")
+    @patch("tap_harvest.discover.get_schemas")
     def test_all_inaccessible_raises_exception(self, mock_get_schemas, mock_check):
         """When all streams are inaccessible, discover() raises an exception."""
         mock_get_schemas.return_value = _make_mock_schemas(["clients", "projects"])

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 from singer.catalog import Catalog
 
 from tap_harvest.discover import discover, check_stream_access
-from tap_harvest.exceptions import HarvestUnauthorizedError, HarvestForbiddenError, HarvestNotFoundError
+from tap_harvest.exceptions import HarvestUnauthorizedError, HarvestForbiddenError, HarvestNotFoundError, HarvestError
 from tap_harvest.streams import STREAMS
 
 
@@ -64,6 +64,13 @@ class TestCheckStreamAccess(unittest.TestCase):
         client.get.side_effect = ConnectionError("timeout")
         with self.assertRaises(ConnectionError):
             check_stream_access(client, "clients", STREAMS["clients"])
+
+    def test_returns_true_on_non_auth_harvest_error(self):
+        """Non-auth HarvestErrors (e.g. 400) mean auth is valid — stream assumed accessible."""
+        client = MagicMock()
+        client.get.side_effect = HarvestError("bad request")
+        result = check_stream_access(client, "clients", STREAMS["clients"])
+        self.assertTrue(result)
 
     def test_probe_uses_per_page_1(self):
         """Probe uses per_page=1 for minimal data fetch."""

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -1,88 +1,181 @@
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 from singer.catalog import Catalog
 
-from tap_harvest.discover import discover
+from tap_harvest.discover import discover, check_stream_access
+from tap_harvest.exceptions import HarvestUnauthorizedError, HarvestForbiddenError
+from tap_harvest.streams import STREAMS
 
+
+def _make_mock_schemas(stream_names):
+    schema = {
+        "type": "object",
+        "properties": {"id": {"type": "integer"}, "updated_at": {"type": "string"}},
+    }
+    mdata = [
+        {
+            "breadcrumb": [],
+            "metadata": {
+                "table-key-properties": ["id"],
+                "forced-replication-method": "INCREMENTAL",
+                "valid-replication-keys": ["updated_at"],
+            },
+        }
+    ]
+    return (
+        {name: schema for name in stream_names},
+        {name: mdata for name in stream_names},
+    )
+
+
+# ---------------------------------------------------------------------------
+# check_stream_access
+# ---------------------------------------------------------------------------
+
+class TestCheckStreamAccess(unittest.TestCase):
+    """Tests for the check_stream_access helper in tap_harvest.discover."""
+
+    def test_top_level_stream_returns_true_when_accessible(self):
+        client = MagicMock()
+        result = check_stream_access(client, "clients", STREAMS["clients"])
+        self.assertTrue(result)
+        client.get.assert_called_once()
+
+    def test_returns_false_on_401(self):
+        client = MagicMock()
+        client.get.side_effect = HarvestUnauthorizedError("401")
+        result = check_stream_access(client, "clients", STREAMS["clients"])
+        self.assertFalse(result)
+
+    def test_returns_false_on_403(self):
+        client = MagicMock()
+        client.get.side_effect = HarvestForbiddenError("403")
+        result = check_stream_access(client, "invoices", STREAMS["invoices"])
+        self.assertFalse(result)
+
+    def test_reraises_other_errors(self):
+        client = MagicMock()
+        client.get.side_effect = ConnectionError("timeout")
+        with self.assertRaises(ConnectionError):
+            check_stream_access(client, "clients", STREAMS["clients"])
+
+    def test_probe_uses_per_page_1(self):
+        """Probe uses per_page=1 for minimal data fetch."""
+        client = MagicMock()
+        check_stream_access(client, "clients", STREAMS["clients"])
+        call_kwargs = client.get.call_args
+        params = call_kwargs.kwargs.get("params") or call_kwargs[1].get("params")
+        self.assertEqual(params.get("per_page"), 1)
+
+
+# ---------------------------------------------------------------------------
+# discover()
+# ---------------------------------------------------------------------------
 
 class TestDiscover(unittest.TestCase):
     """Tests for tap_harvest.discover.discover()."""
 
+    @patch("tap_harvest.discover.check_stream_access")
     @patch("tap_harvest.discover.get_schemas")
-    def test_discover_returns_catalog(self, mock_get_schemas):
+    def test_discover_returns_catalog(self, mock_get_schemas, mock_check):
         """discover() returns a Catalog object."""
-        mock_schema = {
-            "type": "object",
-            "properties": {"id": {"type": "integer"}, "updated_at": {"type": "string"}},
-        }
-        mock_mdata = [
-            {
-                "breadcrumb": [],
-                "metadata": {
-                    "table-key-properties": ["id"],
-                    "forced-replication-method": "INCREMENTAL",
-                    "valid-replication-keys": ["updated_at"],
-                },
-            }
-        ]
-        mock_get_schemas.return_value = (
-            {"clients": mock_schema},
-            {"clients": mock_mdata},
-        )
+        mock_get_schemas.return_value = _make_mock_schemas(["clients"])
+        mock_check.return_value = True
 
-        catalog = discover()
+        catalog = discover(MagicMock())
 
         self.assertIsInstance(catalog, Catalog)
         self.assertEqual(len(catalog.streams), 1)
         self.assertEqual(catalog.streams[0].stream, "clients")
         self.assertEqual(catalog.streams[0].tap_stream_id, "clients")
 
+    @patch("tap_harvest.discover.check_stream_access")
     @patch("tap_harvest.discover.get_schemas")
-    def test_discover_sets_key_properties(self, mock_get_schemas):
+    def test_discover_sets_key_properties(self, mock_get_schemas, mock_check):
         """discover() sets key_properties from metadata table-key-properties."""
-        mock_schema = {
-            "type": "object",
-            "properties": {"id": {"type": "integer"}},
-        }
-        mock_mdata = [
-            {
-                "breadcrumb": [],
-                "metadata": {
-                    "table-key-properties": ["id"],
-                    "forced-replication-method": "FULL_TABLE",
-                    "valid-replication-keys": [],
-                },
-            }
-        ]
-        mock_get_schemas.return_value = (
-            {"roles": mock_schema},
-            {"roles": mock_mdata},
-        )
+        mock_get_schemas.return_value = _make_mock_schemas(["roles"])
+        mock_check.return_value = True
 
-        catalog = discover()
+        catalog = discover(MagicMock())
         self.assertEqual(catalog.streams[0].key_properties, ["id"])
 
+    @patch("tap_harvest.discover.check_stream_access")
     @patch("tap_harvest.discover.get_schemas")
-    def test_discover_multiple_streams(self, mock_get_schemas):
+    def test_discover_multiple_streams(self, mock_get_schemas, mock_check):
         """discover() handles multiple streams without error."""
-        make_schema = lambda: {
-            "type": "object",
-            "properties": {"id": {"type": "integer"}, "updated_at": {"type": "string"}},
-        }
-        make_mdata = lambda: [
-            {
-                "breadcrumb": [],
-                "metadata": {
-                    "table-key-properties": ["id"],
-                    "forced-replication-method": "INCREMENTAL",
-                    "valid-replication-keys": ["updated_at"],
-                },
-            }
-        ]
-        schemas = {name: make_schema() for name in ["clients", "projects", "tasks"]}
-        field_metadata = {name: make_mdata() for name in ["clients", "projects", "tasks"]}
-        mock_get_schemas.return_value = (schemas, field_metadata)
+        mock_get_schemas.return_value = _make_mock_schemas(["clients", "projects", "tasks"])
+        mock_check.return_value = True
 
-        catalog = discover()
+        catalog = discover(MagicMock())
         stream_ids = {s.tap_stream_id for s in catalog.streams}
         self.assertEqual(stream_ids, {"clients", "projects", "tasks"})
+
+    @patch("tap_harvest.discover.check_stream_access")
+    @patch("tap_harvest.discover.get_schemas")
+    def test_child_stream_excluded_when_parent_inaccessible(self, mock_get_schemas, mock_check):
+        """Child streams are excluded from the catalog when their parent stream is inaccessible."""
+        # invoices (parent) + invoice_payments (child) + clients (accessible top-level)
+        mock_get_schemas.return_value = _make_mock_schemas(["invoices", "invoice_payments", "clients"])
+        # invoices blocked, clients accessible — ensures catalog is non-empty so no exception fires
+        mock_check.side_effect = lambda client, name, cls: name != "invoices"
+
+        catalog = discover(MagicMock())
+        stream_ids = {s.tap_stream_id for s in catalog.streams}
+        self.assertNotIn("invoices", stream_ids)
+        self.assertNotIn("invoice_payments", stream_ids)
+        self.assertIn("clients", stream_ids)
+
+    @patch("tap_harvest.discover.check_stream_access")
+    @patch("tap_harvest.discover.get_schemas")
+    def test_child_stream_included_when_parent_accessible(self, mock_get_schemas, mock_check):
+        """Child streams are included when their parent stream is accessible."""
+        mock_get_schemas.return_value = _make_mock_schemas(["invoices", "invoice_payments"])
+        mock_check.return_value = True  # invoices accessible
+
+        catalog = discover(MagicMock())
+        stream_ids = {s.tap_stream_id for s in catalog.streams}
+        self.assertIn("invoices", stream_ids)
+        self.assertIn("invoice_payments", stream_ids)
+
+    @patch("tap_harvest.discover.check_stream_access")
+    @patch("tap_harvest.discover.get_schemas")
+    def test_inaccessible_stream_excluded(self, mock_get_schemas, mock_check):
+        """Streams that fail the access check are excluded from the catalog."""
+        mock_get_schemas.return_value = _make_mock_schemas(["clients", "projects", "tasks"])
+        mock_check.side_effect = lambda client, name, cls: name != "clients"
+
+        catalog = discover(MagicMock())
+        stream_ids = {s.tap_stream_id for s in catalog.streams}
+        self.assertNotIn("clients", stream_ids)
+        self.assertEqual(stream_ids, {"projects", "tasks"})
+
+    @patch("tap_harvest.discover.check_stream_access")
+    @patch("tap_harvest.discover.get_schemas")
+    def test_all_inaccessible_raises_exception(self, mock_get_schemas, mock_check):
+        """When all streams are inaccessible, discover() raises an exception."""
+        mock_get_schemas.return_value = _make_mock_schemas(["clients", "projects"])
+        mock_check.return_value = False
+
+        with self.assertRaises(Exception) as ctx:
+            discover(MagicMock())
+        self.assertIn("No stream endpoints are accessible", str(ctx.exception))
+
+    @patch("tap_harvest.discover.check_stream_access")
+    @patch("tap_harvest.discover.get_schemas")
+    def test_warning_logged_for_excluded_stream(self, mock_get_schemas, mock_check):
+        """A warning is logged for each excluded stream."""
+        mock_get_schemas.return_value = _make_mock_schemas(["clients", "projects"])
+        mock_check.side_effect = lambda client, name, cls: name != "clients"
+
+        with patch("tap_harvest.discover.LOGGER") as mock_logger:
+            discover(MagicMock())
+
+        warned_streams = [
+            call.args[1] for call in mock_logger.warning.call_args_list
+        ]
+        self.assertIn("clients", warned_streams)
+        self.assertNotIn("projects", warned_streams)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unittests/test_init.py
+++ b/tests/unittests/test_init.py
@@ -14,12 +14,13 @@ class TestDoDiscover(unittest.TestCase):
         mock_catalog = MagicMock()
         mock_catalog.to_dict.return_value = {"streams": []}
         mock_discover.return_value = mock_catalog
+        mock_client = MagicMock()
 
         captured = io.StringIO()
         with patch("sys.stdout", captured):
-            tap_harvest.do_discover()
+            tap_harvest.do_discover(mock_client)
 
-        mock_discover.assert_called_once()
+        mock_discover.assert_called_once_with(mock_client)
         mock_catalog.to_dict.assert_called_once()
         output = json.loads(captured.getvalue())
         self.assertEqual(output, {"streams": []})
@@ -30,10 +31,11 @@ class TestDoDiscover(unittest.TestCase):
         mock_catalog = MagicMock()
         mock_catalog.to_dict.return_value = {}
         mock_discover.return_value = mock_catalog
+        mock_client = MagicMock()
 
         with patch("tap_harvest.LOGGER") as mock_logger:
             with patch("sys.stdout", io.StringIO()):
-                tap_harvest.do_discover()
+                tap_harvest.do_discover(mock_client)
 
         self.assertTrue(mock_logger.info.called)
         calls = [str(c) for c in mock_logger.info.call_args_list]


### PR DESCRIPTION
# Description of change

Credentials scoped to a subset of Harvest streams would previously cause discovery to return a full catalog, leading to runtime errors when sync attempted to read inaccessible streams. This surfaces permission failures at discovery time with a clear message.

## Key decisions

- **Child stream detection uses `cls.parent`** (not `'{}' in cls.path`). Virtual child streams like `invoice_line_items` and `user_roles` have flat paths but a non-empty `parent` — the path check incorrectly classified them as top-level.
- **404 → `False`**: a missing endpoint should exclude the stream, not silently include it.
- **Non-auth `HarvestError` → `True` with warning**: a non-401/403/404 response means the credentials were accepted; the stream is assumed accessible.
- **Two-pass ordering**: top-level streams are probed first so parent accessibility is established before children are evaluated.

## Testing

- Unit tests added in `tests/unittests/test_discover.py` covering: 401, 403, 404, non-auth error, virtual child inclusion/exclusion, all-inaccessible empty-catalog guard.
- Existing integration tests unchanged.


# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
