### PR TITLE
Add explicit HarvestBackoffError handling to avoid throttling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.1.2
+  * Add 15s retry backoff for Harvest Backoff Error [#74](https://github.com/singer-io/tap-harvest/pull/74)
+
 ## 3.1.1
   * Dependabot requests update [#72](https://github.com/singer-io/tap-harvest/pull/72)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 3.1.2
-  * Add 15s retry backoff for Harvest Backoff Error [#74](https://github.com/singer-io/tap-harvest/pull/74)
+  * Add retry backoff for Harvest Backoff Error [#74](https://github.com/singer-io/tap-harvest/pull/74)
 
 ## 3.1.1
   * Dependabot requests update [#72](https://github.com/singer-io/tap-harvest/pull/72)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="tap-harvest",
-    version="3.1.1",
+    version="3.1.2",
     description="Singer.io tap for extracting data from the Harvest api",
     author="Facet Interactive",
     url="http://singer.io",

--- a/tap_harvest/client.py
+++ b/tap_harvest/client.py
@@ -16,6 +16,29 @@ from tap_harvest.exceptions import (
 LOGGER = get_logger()
 REQUEST_TIMEOUT = 300
 REFRESH_URL = "https://id.getharvest.com/api/v2"
+MAX_RETRIES = 7
+
+
+def _on_backoff(details):
+    """Log when backing off due to retryable errors."""
+    exc = details.get("exception")
+    wait = details["wait"]
+    if exc and hasattr(exc, "response") and exc.response is not None:
+        retry_after = exc.response.headers.get("Retry-After")
+        if retry_after:
+            LOGGER.warning(
+                "Rate limited. Retry-After: %s seconds. Backing off %.1f seconds after %d tries.",
+                retry_after,
+                wait,
+                details["tries"],
+            )
+            return
+    LOGGER.warning(
+        "Backing off %.1f seconds after %d tries calling %s",
+        wait,
+        details["tries"],
+        details["target"].__name__,
+    )
 
 
 def raise_for_error(response: requests.Response) -> None:
@@ -160,10 +183,17 @@ class Client:
             ConnectionError,
             ChunkedEncodingError,
             Timeout,
-            HarvestBackoffError,
         ),
-        max_tries=5,
+        max_tries=MAX_RETRIES,
         factor=2,
+        on_backoff=_on_backoff,
+    )
+    @backoff.on_exception(
+        wait_gen=backoff.expo,
+        exception=HarvestBackoffError,
+        max_tries=MAX_RETRIES,
+        factor=15,
+        on_backoff=_on_backoff,
     )
     def __make_request(
         self, method: str, endpoint: str, **kwargs

--- a/tap_harvest/client.py
+++ b/tap_harvest/client.py
@@ -16,29 +16,7 @@ from tap_harvest.exceptions import (
 LOGGER = get_logger()
 REQUEST_TIMEOUT = 300
 REFRESH_URL = "https://id.getharvest.com/api/v2"
-MAX_RETRIES = 7
-
-
-def _on_backoff(details):
-    """Log when backing off due to retryable errors."""
-    exc = details.get("exception")
-    wait = details["wait"]
-    if exc and hasattr(exc, "response") and exc.response is not None:
-        retry_after = exc.response.headers.get("Retry-After")
-        if retry_after:
-            LOGGER.warning(
-                "Rate limited. Retry-After: %s seconds. Backing off %.1f seconds after %d tries.",
-                retry_after,
-                wait,
-                details["tries"],
-            )
-            return
-    LOGGER.warning(
-        "Backing off %.1f seconds after %d tries calling %s",
-        wait,
-        details["tries"],
-        details["target"].__name__,
-    )
+MAX_RETRIES = 5
 
 
 def raise_for_error(response: requests.Response) -> None:
@@ -186,14 +164,12 @@ class Client:
         ),
         max_tries=MAX_RETRIES,
         factor=2,
-        on_backoff=_on_backoff,
     )
     @backoff.on_exception(
         wait_gen=backoff.expo,
         exception=HarvestBackoffError,
         max_tries=MAX_RETRIES,
         factor=15,
-        on_backoff=_on_backoff,
     )
     def __make_request(
         self, method: str, endpoint: str, **kwargs

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -79,7 +79,7 @@ class TestMakeRequest(unittest.TestCase):
                 client.get(url, params, headers)
 
         # Ensure the request was retried up to the backoff limit
-        self.assertEqual(mocked_request.call_count, 7)
+        self.assertEqual(mocked_request.call_count, 5)
 
     @patch("time.sleep")
     @patch("requests.Session.request", side_effect=Timeout)
@@ -101,7 +101,7 @@ class TestMakeRequest(unittest.TestCase):
                 client.get(url, params, headers)
 
         # Ensure the request was retried up to the backoff limit
-        self.assertEqual(mocked_request.call_count, 7)
+        self.assertEqual(mocked_request.call_count, 5)
 
     @patch("time.sleep")
     @patch("requests.Session.request", side_effect=ChunkedEncodingError)
@@ -123,7 +123,7 @@ class TestMakeRequest(unittest.TestCase):
                 client.get(url, params, headers)
 
         # Ensure the request was retried up to the backoff limit
-        self.assertEqual(mocked_request.call_count, 7)
+        self.assertEqual(mocked_request.call_count, 5)
 
     @patch("time.sleep")
     @patch("requests.Session.request")
@@ -133,7 +133,7 @@ class TestMakeRequest(unittest.TestCase):
         """Test case for 429 Rate Limit error."""
         mocked_request.side_effect = [
             get_response(429, {}, True)
-        ] * 7  # Simulate 7 retries for 429 error
+        ] * 5  # Simulate 5 retries for 429 error
         url = "dummy_endpoint"
         params = {}
         headers = {"Authorization": "Bearer dummy_token"}
@@ -148,7 +148,7 @@ class TestMakeRequest(unittest.TestCase):
                 client.get(url, params, headers)
 
         # Ensure the request was retried up to the backoff limit
-        self.assertEqual(mocked_request.call_count, 7)
+        self.assertEqual(mocked_request.call_count, 5)
 
     @patch("time.sleep")
     @patch("requests.Session.request")

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -79,7 +79,7 @@ class TestMakeRequest(unittest.TestCase):
                 client.get(url, params, headers)
 
         # Ensure the request was retried up to the backoff limit
-        self.assertEqual(mocked_request.call_count, 5)
+        self.assertEqual(mocked_request.call_count, 7)
 
     @patch("time.sleep")
     @patch("requests.Session.request", side_effect=Timeout)
@@ -101,7 +101,7 @@ class TestMakeRequest(unittest.TestCase):
                 client.get(url, params, headers)
 
         # Ensure the request was retried up to the backoff limit
-        self.assertEqual(mocked_request.call_count, 5)
+        self.assertEqual(mocked_request.call_count, 7)
 
     @patch("time.sleep")
     @patch("requests.Session.request", side_effect=ChunkedEncodingError)
@@ -123,7 +123,7 @@ class TestMakeRequest(unittest.TestCase):
                 client.get(url, params, headers)
 
         # Ensure the request was retried up to the backoff limit
-        self.assertEqual(mocked_request.call_count, 5)
+        self.assertEqual(mocked_request.call_count, 7)
 
     @patch("time.sleep")
     @patch("requests.Session.request")
@@ -133,7 +133,7 @@ class TestMakeRequest(unittest.TestCase):
         """Test case for 429 Rate Limit error."""
         mocked_request.side_effect = [
             get_response(429, {}, True)
-        ] * 5  # Simulate 5 retries for 429 error
+        ] * 7  # Simulate 7 retries for 429 error
         url = "dummy_endpoint"
         params = {}
         headers = {"Authorization": "Bearer dummy_token"}
@@ -148,7 +148,32 @@ class TestMakeRequest(unittest.TestCase):
                 client.get(url, params, headers)
 
         # Ensure the request was retried up to the backoff limit
-        self.assertEqual(mocked_request.call_count, 5)
+        self.assertEqual(mocked_request.call_count, 7)
+
+    @patch("time.sleep")
+    @patch("requests.Session.request")
+    def test_harvest_rate_limit_recovers_after_retry(
+        self, mocked_request, mock_sleep, mock_refresh_token, mock_check_active_account
+    ):
+        """Test case for 429 Rate Limit error that recovers after retries."""
+        rate_limit_response = Mockresponse(429, {}, True, headers={"Retry-After": "15"})
+        success_response = get_response(200, {"result": []})
+        mocked_request.side_effect = [
+            rate_limit_response,
+            rate_limit_response,
+            success_response,
+        ]
+        url = "dummy_endpoint"
+        params = {}
+        headers = {"Authorization": "Bearer dummy_token"}
+
+        client_config = {"user_agent": "singer"}
+
+        with Client(client_config) as client:
+            result = client.get(url, params, headers)
+
+        self.assertEqual(result, {"result": []})
+        self.assertEqual(mocked_request.call_count, 3)
 
     @patch("time.sleep")
     @patch("requests.Session.request")


### PR DESCRIPTION
# Description of change
https://qlik-dev.atlassian.net/browse/SAC-31285

- Add retry logic for API backoff with factor 15 (general API requests limit is 100 per 15 seconds [Harvest rate limit docs](https://help.getharvest.com/api-v2/introduction/overview/general/#rate-limiting))
- Add MAX_RETRIES constant
- Add test

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
